### PR TITLE
Rename AIR- ID prefix to SDLC- for identifiers

### DIFF
--- a/docs/_includes/mitigation-id.html
+++ b/docs/_includes/mitigation-id.html
@@ -1,2 +1,2 @@
 {% assign padded_number = "00" | append: include.mitigation.sequence | slice: -3, 3 %}
-AIR-{{ include.mitigation.type }}-{{ padded_number }}
+SDLC-{{ include.mitigation.type }}-{{ padded_number }}

--- a/docs/_includes/risk-id.html
+++ b/docs/_includes/risk-id.html
@@ -1,2 +1,2 @@
 {% assign padded_number = "00" | append: include.risk.sequence | slice: -3, 3 %}
-AIR-{{ include.risk.type }}-{{ padded_number }}
+SDLC-{{ include.risk.type }}-{{ padded_number }}


### PR DESCRIPTION
Update risk and mitigation identifier prefixes from `AIR-` to `SDLC-` in documentation templates.

**Changes:**
- Updated `mitigation-id.html` to use `SDLC-` prefix instead of `AIR-`
- Updated `risk-id.html` to use `SDLC-` prefix instead of `AIR-`

This ensures consistent naming convention across risk and mitigation identifiers in the generated documentation.