### PR TITLE
Add mi-14 Test Evidence Retention mitigation and clarify ri-4 CVE wording

### DIFF
--- a/docs/_mitigations/mi-14_test-evidence.md
+++ b/docs/_mitigations/mi-14_test-evidence.md
@@ -1,0 +1,63 @@
+---
+sequence: 14
+title: Test Evidence Retention
+layout: mitigation
+doc-status: Draft
+type: PREV
+nist-sp-800-53r5_references:
+  - sa-11  # SA-11 Developer Testing And Evaluation
+  - au-12  # AU-12 Audit Record Generation
+  - ca-2   # CA-2 Control Assessments
+  - ca-7   # CA-7 Continuous Monitoring
+  - cm-4   # CM-4 Impact Analyses
+  - sa-15  # SA-15 Development Process, Standards, And Tools
+  - si-2   # SI-2 Flaw Remediation
+mitigates:
+  - ri-5   # Audit and Compliance Evidence Failure
+  - ri-8   # Unauthorised Change
+  - ri-1   # Insider Threat
+related_mitigations:
+  - mi-12  # Deployment Gating
+  - mi-5   # Vulnerability Scanning - SAST
+  - mi-6   # Vulnerability Scanning - DAST
+---
+
+## Summary
+
+Test evidence retention ensures that automated test results are captured, linked to specific code changes, and preserved for audit, providing verifiable proof that software was tested before deployment.
+
+## Description
+
+Test evidence retention addresses the requirement to produce, on demand, machine-generated records that demonstrate testing occurred for any given code change or release. Without retained evidence, an organisation cannot prove to a regulator, auditor, or customer that its test suite operated as intended at the time a change was deployed. The mere existence of a test suite is insufficient — evidence must be tied to specific commits, cover the expected scope, and survive for the full regulatory retention period.
+
+This control is distinct from deployment gating (mi-12), which concerns blocking deployments that fail control criteria. Test evidence retention concerns the preservation and retrievability of the artefacts that those gates and controls generate. An organisation may enforce gates correctly but still face an evidence failure if the resulting records are not retained in a durable, tamper-evident form linked to the change they attest to.
+
+In regulated financial services environments, the inability to produce test evidence for a released change is treated by examiners as equivalent to the testing not having occurred. Coverage metrics, test run logs, pass/fail records, and the identity of the system that executed them form part of the SDLC governance trail required to demonstrate that software development risk is managed.
+
+## Requirements
+
+* Automated test suites MUST be executed as part of the CI/CD pipeline for every pull request targeting a protected branch and every build that produces a deployable artefact
+* Test execution results MUST be captured in a structured, machine-readable format (e.g., JUnit XML, CTRF) and stored as persistent artefacts linked to the triggering commit SHA, branch, pipeline run identifier, and timestamp
+* Code coverage reports MUST be generated for each test run and stored alongside the test results as part of the same artefact bundle
+* Minimum coverage thresholds MUST be defined per repository or service and enforced as a hard CI gate; reductions below the defined threshold MUST be explicitly approved and the approval documented
+* Test evidence artefacts MUST be retained for a minimum period aligned with the organisation's regulatory audit retention policy; this period MUST NOT be less than the longest applicable regulatory retention requirement
+* Retained artefacts MUST be immutable after capture; they MUST NOT be modifiable, deletable, or re-runnable outside an approved and auditable exception process
+* Each deployment record MUST include a reference to the test evidence artefact that corresponds to the artefact being deployed, enabling end-to-end traceability from deployment back to the test run
+* A defined and documented exception process MUST exist for cases where test evidence cannot be produced before deployment; exceptions MUST be approved by an appropriate authority, time-bound, and automatically tracked to closure
+
+## Examples & Commentary
+
+* **Artefact Storage:** Configure CI pipelines to publish test results and coverage reports as pipeline artefacts. Where the pipeline's native retention is short-lived (e.g., 30 days), archive to long-term storage such as an object store with immutable object policies enabled (e.g., S3 Object Lock). Record the artefact location in the deployment record
+* **Traceability:** Tag artefacts with the commit SHA and include this reference in the release record, deployment ticket, and change advisory board entry. This allows an auditor examining any production release to trace back to the specific test run that validated it
+* **Coverage Thresholds:** Define thresholds appropriate to the risk profile of each repository — a payment processing service may require 80% line coverage, while an internal tooling repository may set a lower bar. Document the rationale for the chosen threshold in the repository's governance documentation
+* **Immutability:** Use object storage features such as write-once-read-many (WORM) policies or versioning with deletion protection to ensure artefacts cannot be altered after the pipeline writes them. Audit access logs periodically to detect any access pattern inconsistent with normal read-only retrieval
+* **Relationship to Deployment Gating:** Deployment gating (mi-12) blocks deployment when criteria are not met; test evidence retention ensures the outcome of those gates is preserved as an auditable record. Both controls are required — gating without retention provides enforcement but no audit trail; retention without gating captures evidence of untested deployments
+* **Exceptions:** Where an emergency deployment must proceed without a full passing test run (e.g., a critical production fix under time pressure), the exception process must capture: who approved the exception, the justification, which test requirements were waived, and the remediation commitment. The evidence of the exception itself forms part of the audit record
+
+## Links
+
+- [NIST SP 800-53r5 SA-11: Developer Testing and Evaluation](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 AU-12: Audit Record Generation](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 CA-2: Control Assessments](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SSDF SP 800-218](https://csrc.nist.gov/pubs/sp/800/218/final)
+- [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)

--- a/docs/_risks/ri-4_vulnerable-software-in-production.md
+++ b/docs/_risks/ri-4_vulnerable-software-in-production.md
@@ -27,7 +27,7 @@ This risk has two temporal dimensions. First, known-vulnerable components can en
 
 Unlike supply chain compromise (ri-10, ri-11), which concerns the deliberate introduction of malicious or tampered components, this risk focuses on the presence of known, publicly disclosed vulnerabilities that remain unaddressed in production. Attackers actively scan for known vulnerabilities and can exploit them rapidly once public disclosures are made, making timely detection and remediation critical.
 
-- **Unpatched known vulnerabilities (CVEs)** — Production systems running software with publicly disclosed vulnerabilities for which patches or mitigations are available but have not been applied
+- **Unpatched known vulnerabilities (CVEs)** — Production systems running software with publicly disclosed vulnerabilities that have not been patched or mitigated
 - **Outdated or end-of-life dependencies** — Libraries, frameworks, or runtime components that no longer receive security updates, leaving known vulnerabilities permanently unaddressed
 - **Incomplete vulnerability scanning** — Security scans that do not cover the full software stack — including transitive dependencies, container base images, and runtime libraries — leaving blind spots in vulnerability detection
 - **Delayed remediation cycles** — Organisational processes that are too slow to triage, prioritise, and deploy fixes for critical vulnerabilities before they can be exploited


### PR DESCRIPTION
## Summary

- Adds `mi-14_test-evidence.md` — a new mitigation covering automated test evidence capture, retention, and traceability as a control for ri-5 (Audit and Compliance Evidence Failure), ri-8 (Unauthorised Change), and ri-1 (Insider Threat)
- Removes the implication in ri-4 that an upgrade path must exist for the CVE risk to apply — the risk is present whether or not a patch is available

## Test plan

- [ ] Verify mi-14 renders correctly in the catalogue view
- [ ] Verify NIST 800-53r5 reference links in mi-14 resolve correctly
- [ ] Confirm ri-4 CVE bullet reads correctly in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)