### PR TITLE
Add testing controls chain: mi-15, mi-16, mi-14

### DIFF
--- a/docs/_includes/control-chain.html
+++ b/docs/_includes/control-chain.html
@@ -1,0 +1,35 @@
+{% if include.page.chain %}
+  {% assign chain_id = include.page.chain %}
+  {% assign current_id = "mi-" | append: include.page.sequence %}
+  {% assign chain_members = site.mitigations | where: "chain", chain_id | sort: "sequence" %}
+
+  {% if chain_members.size > 1 %}
+  <div class="control-chain mb-3">
+    {% for member in chain_members %}
+      {% assign m_id = "mi-" | append: member.sequence %}
+      {% assign is_current = false %}
+      {% if m_id == current_id %}
+        {% assign is_current = true %}
+      {% endif %}
+
+      {% if is_current %}
+      <div class="control-chain-step active">
+        <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
+        <div class="chain-name">{{ member.title }}</div>
+      </div>
+      {% else %}
+      <a href="{{ site.baseurl }}/{{ member.url }}" class="control-chain-step text-decoration-none">
+        <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
+        <div class="chain-name">{{ member.title }}</div>
+      </a>
+      {% endif %}
+
+      {% unless forloop.last %}
+      <div class="chain-arrow">
+        <i class="bi bi-chevron-right"></i>
+      </div>
+      {% endunless %}
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endif %}

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -69,10 +69,17 @@ layout: default
             <div class="card mb-4">
                 <div class="card-body">
                     <h2 class="h4 mb-4">Related Mitigations</h2>
+
+                    {% include control-chain.html page=page %}
+
                     <div class="list-group">
                         {% for mitigation in site.mitigations %}
                         {% assign mitigation_prefix = "mi-" | append: mitigation.sequence %}
                         {% if page.related_mitigations contains mitigation_prefix %}
+                        {% comment %} Skip chain members — they are already shown above {% endcomment %}
+                        {% if page.chain and mitigation.chain == page.chain %}
+                        {% continue %}
+                        {% endif %}
                         <div class="list-group-item">
                             <h3 class="h6 mb-1">
                                 <a href="{{ site.baseurl }}/{{ mitigation.url }}">{% include mitigation-id.html mitigation=mitigation %} : {{ mitigation.title }}</a>

--- a/docs/_mitigations/mi-12_deployment-gating.md
+++ b/docs/_mitigations/mi-12_deployment-gating.md
@@ -20,6 +20,9 @@ related_mitigations:
   - mi-7   # Vulnerability Scanning - Dependencies
   - mi-10  # Secret Detection
   - mi-11  # Vulnerability Remediation SLAs
+  - mi-15  # Testing Requirements
+  - mi-16  # Test Execution and Sign-Off
+  - mi-14  # Test Evidence Retention
 ---
 
 ## Summary

--- a/docs/_mitigations/mi-14_test-evidence.md
+++ b/docs/_mitigations/mi-14_test-evidence.md
@@ -4,6 +4,8 @@ title: Test Evidence Retention
 layout: mitigation
 doc-status: Draft
 type: PREV
+chain:
+  - testing-assurance
 nist-sp-800-53r5_references:
   - sa-11  # SA-11 Developer Testing And Evaluation
   - au-12  # AU-12 Audit Record Generation
@@ -15,8 +17,9 @@ nist-sp-800-53r5_references:
 mitigates:
   - ri-5   # Audit and Compliance Evidence Failure
   - ri-8   # Unauthorised Change
-  - ri-1   # Insider Threat
 related_mitigations:
+  - mi-15  # Testing Requirements
+  - mi-16  # Test Execution and Sign-Off
   - mi-12  # Deployment Gating
   - mi-5   # Vulnerability Scanning - SAST
   - mi-6   # Vulnerability Scanning - DAST
@@ -30,16 +33,15 @@ Test evidence retention ensures that automated test results are captured, linked
 
 Test evidence retention addresses the requirement to produce, on demand, machine-generated records that demonstrate testing occurred for any given code change or release. Without retained evidence, an organisation cannot prove to a regulator, auditor, or customer that its test suite operated as intended at the time a change was deployed. The mere existence of a test suite is insufficient — evidence must be tied to specific commits, cover the expected scope, and survive for the full regulatory retention period.
 
-This control is distinct from deployment gating (mi-12), which concerns blocking deployments that fail control criteria. Test evidence retention concerns the preservation and retrievability of the artefacts that those gates and controls generate. An organisation may enforce gates correctly but still face an evidence failure if the resulting records are not retained in a durable, tamper-evident form linked to the change they attest to.
+This control is distinct from test execution (mi-16), which governs whether required testing was performed and any failures appropriately reviewed. Test evidence retention concerns the preservation and retrievability of the artefacts that test execution produces. An organisation may execute testing correctly but still face an evidence failure if the resulting records are not retained in a durable, tamper-evident form linked to the change they attest to.
 
 In regulated financial services environments, the inability to produce test evidence for a released change is treated by examiners as equivalent to the testing not having occurred. Coverage metrics, test run logs, pass/fail records, and the identity of the system that executed them form part of the SDLC governance trail required to demonstrate that software development risk is managed.
 
 ## Requirements
 
 * Automated test suites MUST be executed as part of the CI/CD pipeline for every pull request targeting a protected branch and every build that produces a deployable artefact
-* Test execution results MUST be captured in a structured, machine-readable format (e.g., JUnit XML, CTRF) and stored as persistent artefacts linked to the triggering commit SHA, branch, pipeline run identifier, and timestamp
-* Code coverage reports MUST be generated for each test run and stored alongside the test results as part of the same artefact bundle
-* Minimum coverage thresholds MUST be defined per repository or service and enforced as a hard CI gate; reductions below the defined threshold MUST be explicitly approved and the approval documented
+* For Automated test execution results MUST be captured in a structured, machine-readable format (e.g., JUnit XML, CTRF) and stored as persistent artefacts linked to the triggering commit SHA, branch, pipeline run identifier, and timestamp or any other references to ensure traceability back to the intented release
+* Manual test evidence must be associated with the intented release for traceability, downstream gating and reporting.
 * Test evidence artefacts MUST be retained for a minimum period aligned with the organisation's regulatory audit retention policy; this period MUST NOT be less than the longest applicable regulatory retention requirement
 * Retained artefacts MUST be immutable after capture; they MUST NOT be modifiable, deletable, or re-runnable outside an approved and auditable exception process
 * Each deployment record MUST include a reference to the test evidence artefact that corresponds to the artefact being deployed, enabling end-to-end traceability from deployment back to the test run
@@ -48,11 +50,8 @@ In regulated financial services environments, the inability to produce test evid
 ## Examples & Commentary
 
 * **Artefact Storage:** Configure CI pipelines to publish test results and coverage reports as pipeline artefacts. Where the pipeline's native retention is short-lived (e.g., 30 days), archive to long-term storage such as an object store with immutable object policies enabled (e.g., S3 Object Lock). Record the artefact location in the deployment record
-* **Traceability:** Tag artefacts with the commit SHA and include this reference in the release record, deployment ticket, and change advisory board entry. This allows an auditor examining any production release to trace back to the specific test run that validated it
-* **Coverage Thresholds:** Define thresholds appropriate to the risk profile of each repository — a payment processing service may require 80% line coverage, while an internal tooling repository may set a lower bar. Document the rationale for the chosen threshold in the repository's governance documentation
+* **Traceability:** Tag artefacts with the commit SHA or release tag so that the evidence can be addressible later by downstream gating or for reporting purposes.
 * **Immutability:** Use object storage features such as write-once-read-many (WORM) policies or versioning with deletion protection to ensure artefacts cannot be altered after the pipeline writes them. Audit access logs periodically to detect any access pattern inconsistent with normal read-only retrieval
-* **Relationship to Deployment Gating:** Deployment gating (mi-12) blocks deployment when criteria are not met; test evidence retention ensures the outcome of those gates is preserved as an auditable record. Both controls are required — gating without retention provides enforcement but no audit trail; retention without gating captures evidence of untested deployments
-* **Exceptions:** Where an emergency deployment must proceed without a full passing test run (e.g., a critical production fix under time pressure), the exception process must capture: who approved the exception, the justification, which test requirements were waived, and the remediation commitment. The evidence of the exception itself forms part of the audit record
 
 ## Links
 

--- a/docs/_mitigations/mi-15_testing-requirements.md
+++ b/docs/_mitigations/mi-15_testing-requirements.md
@@ -1,0 +1,61 @@
+---
+sequence: 15
+title: Testing Requirements
+layout: mitigation
+doc-status: Draft
+type: PREV
+chain:
+  - testing-assurance
+nist-sp-800-53r5_references:
+  - sa-11  # SA-11 Developer Testing And Evaluation
+  - sa-15  # SA-15 Development Process, Standards, And Tools
+  - cm-4   # CM-4 Impact Analyses
+mitigates:
+  - ri-4   # Vulnerable Software in Production
+  - ri-5   # Audit and Compliance Evidence Failure
+related_mitigations:
+  - mi-16  # Test Execution and Sign-Off
+  - mi-14  # Test Evidence Retention
+  - mi-12  # Deployment Gating
+  - mi-5   # Vulnerability Scanning - SAST
+  - mi-6   # Vulnerability Scanning - DAST
+  - mi-7   # Vulnerability Scanning - Dependencies
+---
+
+## Summary
+
+A testing policy must be defined that specifies the categories and scope of testing required before any change is released to production, proportionate to the risk profile of the change.
+
+## Description
+
+This control establishes the policy layer of the organisation's testing posture: what types of testing must be performed and when. It does not govern whether the testing was actually executed (mi-16), whether it was enforced mechanically (mi-12), or whether the results were retained (mi-14). Its sole concern is that the organisation has defined, documented, and maintains a testing policy that maps required testing activities to change types.
+
+The testing policy definition defines what degree of testing applies to different change types. This is particularly critical with manual testing due to the overall expense and you may wish to define when it is or is not appropriate to run which suites of testing. Without an explicit testing policy, testing decisions are left to individual judgement and vary across teams, repositories, and release cycles. This creates inconsistency, makes audit response difficult, and means the organisation cannot demonstrate that its testing expectations were defined in advance rather than rationalised after the fact. In regulated financial services environments, examiners expect a documented testing standard that exists independently of any individual release.
+
+The policy must address the full spectrum of change types — from low-risk configuration updates to security-sensitive changes — and define what testing is required for each. It should be specific enough to be enforceable and auditable, but not so prescriptive that it cannot accommodate the diversity of technologies and delivery patterns within the organisation.
+
+## Requirements
+
+* A testing policy MUST be defined that specifies the categories of testing required for each change classification (e.g., patch, minor feature, major release, infrastructure change, security-sensitive change)
+* The policy MUST define a minimum testing baseline that applies to all changes regardless of classification; this baseline MUST include at minimum regression testing to confirm that existing behaviour is not broken
+* Changes to security-sensitive components — including authentication, authorisation, session management, cryptographic operations, and data handling — SHOULD require targeted security testing in addition to functional testing
+* Changes to critical code path that have ben identified as being partocularly sensitive to the application SHOULD require additional testing.
+* The policy MUST define minimum code coverage thresholds per repository or service, with documented rationale for the chosen threshold appropriate to the risk profile of the component
+* The policy MUST specify exit criteria that define what constitutes a passing test outcome for each change classification, including acceptable treatment of pre-existing known failures
+* The testing policy MUST be reviewed at least annually, or when significant changes to the technology stack, threat landscape, or regulatory requirements occur
+
+## Examples & Commentary
+
+* **Change Classification:** Define a simple taxonomy of change types and map required testing to each. For example: a dependency patch may require automated unit and integration tests plus a DAST scan; a new customer-facing feature may additionally require functional UAT and a targeted security review; a change to the authentication flow may require penetration testing or red team exercise sign-off before release
+* **Coverage Thresholds:** Define thresholds appropriate to the risk profile of each repository — a payment processing service may require 80% line coverage, while an internal tooling repository may set a lower bar. Document the rationale for the chosen threshold in the repository's governance documentation
+* **Exit Criteria:** Define release readiness criteria before testing begins, not after. Criteria should specify: no new test failures introduced by the change without documented acceptance; code coverage must not fall below the defined threshold; no new critical or high SAST or DAST findings introduced unresolved; security sign-off obtained for security-sensitive changes. Pre-existing failures that are known, tracked, and unrelated to the change may be accepted without blocking release, provided they are documented. Vague or unwritten criteria are easily gamed and do not provide meaningful assurance
+ase. mi-14 (Test Evidence Retention) ensures the records of completed testing are preserved. All three are required for a complete testing assurance posture
+* **Penetration Testing:**  Is usually an expensive practice sometimes dedicated to a sat of experts who will testing manually or semi-automatically to see if they can breach the system overall. Doing such testing on every release may not be advisable or cost effective, especially if the release was small. This practice will need to be defined somewhere.
+
+## Links
+
+- [NIST SP 800-53r5 SA-11: Developer Testing and Evaluation](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 SA-15: Development Process, Standards, and Tools](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SSDF SP 800-218](https://csrc.nist.gov/pubs/sp/800/218/final)
+- [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)
+- [FFIEC IT Handbook - Information Security](https://ithandbook.ffiec.gov/)

--- a/docs/_mitigations/mi-16_test-execution.md
+++ b/docs/_mitigations/mi-16_test-execution.md
@@ -1,0 +1,55 @@
+---
+sequence: 16
+title: Test Execution and Sign-Off
+layout: mitigation
+doc-status: Draft
+type: PREV
+chain:
+  - testing-assurance
+nist-sp-800-53r5_references:
+  - sa-11  # SA-11 Developer Testing And Evaluation
+  - ca-2   # CA-2 Control Assessments
+  - cm-4   # CM-4 Impact Analyses
+  - si-2   # SI-2 Flaw Remediation
+mitigates:
+  - ri-4   # Vulnerable Software in Production
+  - ri-5   # Audit and Compliance Evidence Failure
+  - ri-8   # Unauthorised Change
+related_mitigations:
+  - mi-15  # Testing Requirements
+  - mi-14  # Test Evidence Retention
+  - mi-12  # Deployment Gating
+  - mi-5   # Vulnerability Scanning - SAST
+  - mi-6   # Vulnerability Scanning - DAST
+---
+
+## Summary
+
+Required appropriate testing as defined by the testing policy (mi-15) must be executed before any change is released to production. Human review and sign-off is required only when test failures occur or when the testing policy cannot be fully satisfied.
+
+## Description
+
+This control governs the execution of testing for each individual release. It bridges the gap between the testing policy (mi-15), which defines what testing must be performed, and the evidence trail (mi-14), which preserves the records of that testing. This control answers the question: for this specific change, was the required testing actually performed, and were the results acceptable?
+
+When all required testing passes and the testing policy is fully satisfied, no manual intervention is needed — the automated pipeline confirms compliance and the release may proceed. Human review and sign-off is required only in two circumstances: when test failures exist that need to be assessed and accepted, or when the testing policy cannot be fully followed and an exception is needed. This keeps the control proportionate — it does not impose manual review overhead on the majority of releases where automated testing passes cleanly, but ensures accountability when it matters.
+
+
+## Requirements
+
+* All changes released to production MUST have completed the testing categories required for their classification as defined in the testing policy (mi-15) before release
+* Where all required testing passes and the testing policy is fully satisfied, the release MAY proceed without manual sign-off; the automated test results constitute sufficient evidence of compliance
+* Where test failures exist in the results failures MUST be explicitly reviewed and either remediated or accepted by a named individual; acceptance MUST be recorded with the identity of the approver, the rationale for acceptance, and confirmation that the failure is not attributable to the change being released
+* Where testing cannot be completed to the required standard prior to release, a documented and approved exception MUST be raised, specifying: who approved the exception, the justification, which test requirements were waived, any compensating controls applied (e.g., enhanced post-deployment monitoring), and a time-bound remediation commitment
+
+## Examples & Commentary
+
+* **Happy Path:** When a change passes all required automated tests, meets coverage thresholds, and satisfies all gate criteria defined in the testing policy, it proceeds to release without requiring manual review. The pipeline run and its results are the evidence — no additional sign-off is needed
+* **Failed Test Acceptance:** When a test failure is accepted rather than remediated, the sign-off record should include: the specific test(s) that failed, the reason the failure is considered acceptable for this release (e.g., pre-existing known issue tracked in ticket X, flaky test under investigation), and the name of the individual accepting the risk. This record forms part of the audit trail and must be preserved per mi-14
+
+## Links
+
+- [NIST SP 800-53r5 SA-11: Developer Testing and Evaluation](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 CA-2: Control Assessments](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SSDF SP 800-218](https://csrc.nist.gov/pubs/sp/800/218/final)
+- [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)
+- [FFIEC IT Handbook - Information Security](https://ithandbook.ffiec.gov/)

--- a/docs/style.css
+++ b/docs/style.css
@@ -258,6 +258,82 @@ a:focus {
     outline-offset: 2px;
 }
 
+/* Control chain styling */
+.control-chain {
+    display: flex;
+    align-items: center;
+    gap: 0;
+}
+
+.control-chain-step {
+    flex: 1;
+    text-align: center;
+    padding: 0.75rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 2px solid #e9ecef;
+    background: #f8f9fa;
+    transition: all 0.2s ease-in-out;
+    min-width: 0;
+}
+
+.control-chain-step:hover {
+    border-color: #198754;
+    background: #fff;
+    transform: none !important;
+    box-shadow: 0 2px 8px rgba(25, 135, 84, 0.15) !important;
+}
+
+.control-chain-step.active {
+    border-color: #198754;
+    background: #198754;
+    color: #fff;
+}
+
+.control-chain-step.active .mitigation-id {
+    color: #fff;
+}
+
+.control-chain-step.active .chain-name {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.chain-title {
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.chain-name {
+    font-size: 0.75rem;
+    color: #6c757d;
+    margin-top: 0.15rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.chain-arrow {
+    padding: 0 0.35rem;
+    color: #adb5bd;
+    font-size: 0.85rem;
+    flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+    .control-chain {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .control-chain-step {
+        width: 100%;
+    }
+
+    .chain-arrow {
+        transform: rotate(90deg);
+        padding: 0.25rem 0;
+    }
+}
+
 /* Print styles */
 @media print {
     .btn, 


### PR DESCRIPTION
## Summary

- **Splits testing controls into three distinct layers** forming a testing assurance chain:
  - **mi-15 Testing Requirements** — policy layer: what testing is required per change classification
  - **mi-16 Test Execution and Sign-Off** — execution layer: ensures testing is performed, with human sign-off only when failures need accepting or the policy cannot be fully satisfied
  - **mi-14 Test Evidence Retention** — evidence layer: preserves test artefacts for audit and traceability
- **Adds a control chain feature** to the site: controls with a shared `chain` ID in their front matter render a visual stepper in the Related Mitigations sidebar, showing how controls relate sequentially. Chain members are excluded from the related mitigations list to avoid duplication.
- **Updates mi-12 (Deployment Gating)** cross-references to link to the new testing controls, while keeping mi-12 focused on its broader deployment gating role rather than being positioned as a testing control.

## Test plan

- [ ] Verify the site builds cleanly (`bundle exec jekyll build` or Docker)
- [ ] Check mi-14, mi-15, mi-16 pages each show the chain stepper in Related Mitigations
- [ ] Check the active step is highlighted and non-active steps are clickable links
- [ ] Check non-chain related mitigations still appear in the list below the chain
- [ ] Check mitigations without a chain (e.g., mi-5) render Related Mitigations as before
- [ ] Verify mi-12 page shows mi-14, mi-15, mi-16 in its Related Mitigations list
- [ ] Check responsive behaviour — chain should stack vertically on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)