### PR TITLE
Fix control chain rendering for array-based chain field

### DIFF
--- a/docs/_includes/control-chain.html
+++ b/docs/_includes/control-chain.html
@@ -1,35 +1,40 @@
 {% if include.page.chain %}
-  {% assign chain_id = include.page.chain %}
   {% assign current_id = "mi-" | append: include.page.sequence %}
-  {% assign chain_members = site.mitigations | where: "chain", chain_id | sort: "sequence" %}
 
-  {% if chain_members.size > 1 %}
-  <div class="control-chain mb-3">
-    {% for member in chain_members %}
-      {% assign m_id = "mi-" | append: member.sequence %}
-      {% assign is_current = false %}
-      {% if m_id == current_id %}
-        {% assign is_current = true %}
+  {% for chain_id in include.page.chain %}
+    {% comment %} Collect all mitigations whose chain array contains this chain_id {% endcomment %}
+    {% assign chain_members = "" | split: "" %}
+    {% for m in site.mitigations %}
+      {% if m.chain contains chain_id %}
+        {% assign chain_members = chain_members | push: m %}
       {% endif %}
-
-      {% if is_current %}
-      <div class="control-chain-step active">
-        <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
-        <div class="chain-name">{{ member.title }}</div>
-      </div>
-      {% else %}
-      <a href="{{ site.baseurl }}/{{ member.url }}" class="control-chain-step text-decoration-none">
-        <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
-        <div class="chain-name">{{ member.title }}</div>
-      </a>
-      {% endif %}
-
-      {% unless forloop.last %}
-      <div class="chain-arrow">
-        <i class="bi bi-chevron-right"></i>
-      </div>
-      {% endunless %}
     {% endfor %}
-  </div>
-  {% endif %}
+    {% assign chain_members = chain_members | sort: "sequence" %}
+
+    {% if chain_members.size > 1 %}
+    <div class="control-chain mb-3">
+      {% for member in chain_members %}
+        {% assign m_id = "mi-" | append: member.sequence %}
+
+        {% if m_id == current_id %}
+        <div class="control-chain-step active">
+          <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
+          <div class="chain-name">{{ member.title }}</div>
+        </div>
+        {% else %}
+        <a href="{{ site.baseurl }}/{{ member.url }}" class="control-chain-step text-decoration-none">
+          <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
+          <div class="chain-name">{{ member.title }}</div>
+        </a>
+        {% endif %}
+
+        {% unless forloop.last %}
+        <div class="chain-arrow">
+          <i class="bi bi-chevron-right"></i>
+        </div>
+        {% endunless %}
+      {% endfor %}
+    </div>
+    {% endif %}
+  {% endfor %}
 {% endif %}

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -77,9 +77,16 @@ layout: default
                         {% assign mitigation_prefix = "mi-" | append: mitigation.sequence %}
                         {% if page.related_mitigations contains mitigation_prefix %}
                         {% comment %} Skip chain members — they are already shown above {% endcomment %}
-                        {% if page.chain and mitigation.chain == page.chain %}
-                        {% continue %}
+                        {% assign skip_mitigation = false %}
+                        {% if page.chain %}
+                          {% for chain_id in page.chain %}
+                            {% if mitigation.chain contains chain_id %}
+                              {% assign skip_mitigation = true %}
+                              {% break %}
+                            {% endif %}
+                          {% endfor %}
                         {% endif %}
+                        {% if skip_mitigation %}{% continue %}{% endif %}
                         <div class="list-group-item">
                             <h3 class="h6 mb-1">
                                 <a href="{{ site.baseurl }}/{{ mitigation.url }}">{% include mitigation-id.html mitigation=mitigation %} : {{ mitigation.title }}</a>


### PR DESCRIPTION
## Summary

- Fixes the control chain stepper not rendering on mitigation pages
- Jekyll's `where` filter doesn't match inside YAML arrays, so the chain lookup was returning no results
- Switches to iterating mitigations and using `contains` to find chain members
- Also fixes the skip logic that deduplicates chain members from the Related Mitigations list

Followup to PR #59.

## Test plan

- [ ] Verify the chain stepper renders on mi-14, mi-15, mi-16 pages
- [ ] Verify chain members are excluded from the list below the stepper
- [ ] Verify non-chain mitigations (e.g. mi-5) render Related Mitigations as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)