### PR TITLE
Fix double-slash in control chain links

### DIFF
--- a/docs/_includes/control-chain.html
+++ b/docs/_includes/control-chain.html
@@ -2,18 +2,21 @@
   {% assign current_id = "mi-" | append: include.page.sequence %}
 
   {% for chain_id in include.page.chain %}
-    {% comment %} Collect all mitigations whose chain array contains this chain_id {% endcomment %}
-    {% assign chain_members = "" | split: "" %}
-    {% for m in site.mitigations %}
+    {% comment %} Render chain members sorted by sequence — no push needed {% endcomment %}
+    {% assign chain_members = site.mitigations | sort: "sequence" %}
+    {% assign chain_count = 0 %}
+    {% for m in chain_members %}
       {% if m.chain contains chain_id %}
-        {% assign chain_members = chain_members | push: m %}
+        {% assign chain_count = chain_count | plus: 1 %}
       {% endif %}
     {% endfor %}
-    {% assign chain_members = chain_members | sort: "sequence" %}
 
-    {% if chain_members.size > 1 %}
+    {% if chain_count > 1 %}
     <div class="control-chain mb-3">
+      {% assign rendered = 0 %}
       {% for member in chain_members %}
+        {% unless member.chain contains chain_id %}{% continue %}{% endunless %}
+        {% assign rendered = rendered | plus: 1 %}
         {% assign m_id = "mi-" | append: member.sequence %}
 
         {% if m_id == current_id %}
@@ -28,11 +31,11 @@
         </a>
         {% endif %}
 
-        {% unless forloop.last %}
+        {% if rendered < chain_count %}
         <div class="chain-arrow">
           <i class="bi bi-chevron-right"></i>
         </div>
-        {% endunless %}
+        {% endif %}
       {% endfor %}
     </div>
     {% endif %}

--- a/docs/_includes/control-chain.html
+++ b/docs/_includes/control-chain.html
@@ -22,7 +22,7 @@
           <div class="chain-name">{{ member.title }}</div>
         </div>
         {% else %}
-        <a href="{{ site.baseurl }}/{{ member.url }}" class="control-chain-step text-decoration-none">
+        <a href="{{ member.url | prepend: site.baseurl }}" class="control-chain-step text-decoration-none">
           <div class="chain-title">{% include mitigation-id.html mitigation=member %}</div>
           <div class="chain-name">{{ member.title }}</div>
         </a>

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -56,7 +56,7 @@ layout: default
                         {% if page.mitigates contains risk_prefix %}
                         <div class="list-group-item">
                             <h3 class="h6 mb-1">
-                                <a href="{{ site.baseurl }}/{{ risk.url }}">{% include risk-id.html risk=risk %} : {{ risk.title }}</a>
+                                <a href="{{ risk.url | prepend: site.baseurl }}">{% include risk-id.html risk=risk %} : {{ risk.title }}</a>
                             </h3>
                         </div>
                         {% endif %}
@@ -89,7 +89,7 @@ layout: default
                         {% if skip_mitigation %}{% continue %}{% endif %}
                         <div class="list-group-item">
                             <h3 class="h6 mb-1">
-                                <a href="{{ site.baseurl }}/{{ mitigation.url }}">{% include mitigation-id.html mitigation=mitigation %} : {{ mitigation.title }}</a>
+                                <a href="{{ mitigation.url | prepend: site.baseurl }}">{% include mitigation-id.html mitigation=mitigation %} : {{ mitigation.title }}</a>
                             </h3>
                         </div>
                         {% endif %}

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -58,7 +58,7 @@ layout: default
                         {% if related_risk %}
                         <div class="list-group-item">
                             <h3 class="h6 mb-1">
-                                <a href="{{ site.baseurl }}/{{ related_risk.url }}">{{ risk_id | upcase }}: {{ related_risk.title }}</a>
+                                <a href="{{ related_risk.url | prepend: site.baseurl }}">{{ risk_id | upcase }}: {{ related_risk.title }}</a>
                             </h3>
                         </div>
                         {% else %}
@@ -79,7 +79,7 @@ layout: default
                         {% for mitigation in related_mitigations %}
                         <div class="list-group-item">
                             <h3 class="h6 mb-1">
-                                <a href="{{ site.baseurl }}/{{ mitigation.url }}">{% include mitigation-id.html mitigation=mitigation %} : {{ mitigation.title }}</a>
+                                <a href="{{ mitigation.url | prepend: site.baseurl }}">{% include mitigation-id.html mitigation=mitigation %} : {{ mitigation.title }}</a>
                             </h3>
                         </div>
                         {% endfor %}


### PR DESCRIPTION
## Summary

- Fixes double-slash in control chain stepper links (e.g. `/SDLC-Controls-Framework//mitigations/...`)
- Uses Liquid `prepend` filter instead of string interpolation to correctly join `baseurl` with `member.url`

Followup to PR #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)