### PR TITLE
Fix mi-17 formatting to match framework conventions

### DIFF
--- a/docs/_mitigations/mi-17_service-dependency-control.md
+++ b/docs/_mitigations/mi-17_service-dependency-control.md
@@ -4,6 +4,9 @@ title: Service Dependency Control
 layout: mitigation
 doc-status: Draft
 type: PREV
+nist-sp-800-53r5_references:
+  - cm-8   # CM-8 System Component Inventory
+  - si-4   # SI-4 System Monitoring
 mitigates:
   - ri-4   # Vulnerable Software in Production
   - ri-7   # Configuration Drift
@@ -18,8 +21,6 @@ related_mitigations:
 Service Dependency Mapping provides visibility into how services, external APIs, and shared components interact across systems and applications. It enables faster incident response, coordinated remediation, and reduced operational risk by maintaining an accurate, up-to-date view of runtime dependencies and their relationships at both service and application levels.
 
 This control complements Component Inventory by extending visibility from artifact-level composition to runtime service and application-level dependency relationships.
-
----
 
 ## Description
 
@@ -40,50 +41,29 @@ This control includes:
 
 Maintaining this mapping ensures that when a failure, vulnerability, or change occurs, its impact can be quickly understood across all affected services and applications, enabling faster and more coordinated responses.
 
----
-
 ## Requirements
 
-1. Service-to-service dependencies MUST be documented and maintained for all production systems.
-
-2. Dependencies MUST include:
-- Internal services
-- External APIs and third-party integrations
-- Shared libraries and platform components (where relevant at runtime)
-
-3. Each service MUST be mapped to its corresponding application or business capability.
-
-4. Ownership information MUST be maintained for each service and application to enable clear accountability during incidents.
-
-5. Dependency mappings MUST capture upstream and downstream relationships to identify impact propagation.
-
-6. Dependency data MUST be kept up to date with production deployments and infrastructure changes.
-
-7. Changes to dependencies (e.g., new integrations, deprecated APIs, version upgrades) MUST be reflected in the mapping as part of the change management process.
-
-8. Dependency mapping SHOULD be integrated with observability, incident management, or service catalog systems where possible.
-
----
+* Service-to-service dependencies MUST be documented and maintained for all production systems
+* Dependencies MUST include:
+  - Internal services
+  - External APIs and third-party integrations
+  - Shared libraries and platform components (where relevant at runtime)
+* Each service MUST be mapped to its corresponding application or business capability
+* Ownership information MUST be maintained for each service and application to enable clear accountability during incidents
+* Dependency mappings MUST capture upstream and downstream relationships to identify impact propagation
+* Dependency data MUST be kept up to date with production deployments and infrastructure changes
+* Changes to dependencies (e.g., new integrations, deprecated APIs, version upgrades) MUST be reflected in the mapping as part of the change management process
+* Dependency mapping SHOULD be integrated with observability, incident management, or service catalog systems where possible
 
 ## Examples & Commentary
 
-- When a critical vulnerability (e.g., Log4j) is identified in a shared library, dependency mapping enables teams to quickly identify:
-- All services using the affected library
-- All applications those services belong to
-- The teams responsible for remediation
-This allows coordinated fixes within defined timelines across the organization.
-
-- If an external API or third-party provider becomes unavailable or deprecated, dependency mapping allows identification of all dependent services and applications, enabling faster remediation and reducing production incidents.
-
-- In distributed trading or real-time systems, if one service fails, dependency mapping helps identify downstream services and applications impacted, allowing proactive communication and mitigation.
-
-- During platform or OS upgrades (e.g., encryption or protocol changes), dependency mapping ensures all affected services and applications are identified, preventing runtime failures due to incompatibility.
-
-- In incident response scenarios, dependency mapping reduces mean time to restore (MTTR) by enabling responders to quickly understand system relationships instead of relying on incomplete or outdated documentation.
-
----
+* **Vulnerability Propagation:** When a critical vulnerability (e.g., Log4j) is identified in a shared library, dependency mapping enables teams to quickly identify all services using the affected library, all applications those services belong to, and the teams responsible for remediation. This allows coordinated fixes within defined timelines across the organization
+* **API Deprecation:** If an external API or third-party provider becomes unavailable or deprecated, dependency mapping allows identification of all dependent services and applications, enabling faster remediation and reducing production incidents
+* **Failure Propagation:** In distributed trading or real-time systems, if one service fails, dependency mapping helps identify downstream services and applications impacted, allowing proactive communication and mitigation
+* **Platform Upgrades:** During platform or OS upgrades (e.g., encryption or protocol changes), dependency mapping ensures all affected services and applications are identified, preventing runtime failures due to incompatibility
+* **Incident Response:** Dependency mapping reduces mean time to restore (MTTR) by enabling responders to quickly understand system relationships instead of relying on incomplete or outdated documentation
 
 ## Links
 
-- NIST SP 800-53r5 CM-8: System Component Inventory
-- NIST SP 800-53r5 SI-4: System Monitoring
+- [NIST SP 800-53r5 CM-8: System Component Inventory](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 SI-4: System Monitoring](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)


### PR DESCRIPTION
## Summary

Formatting fixes for mi-17 (Service Dependency Control) from PR #63 to align with existing control conventions:

- Move NIST references into structured `nist-sp-800-53r5_references` front matter so they render in reference cards
- Convert numbered requirements to bullet points (`*`) matching all other controls
- Remove `---` horizontal rule section dividers not used elsewhere
- Format examples with `**bold labels**` matching other controls
- Convert Links section from plain text to proper hyperlinks

Content is unchanged — formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)