### PR TITLE
New mi-18 for dependencies curation and Update mi-14_test-evidence.md …

### DIFF
--- a/docs/_mitigations/mi-14_test-evidence.md
+++ b/docs/_mitigations/mi-14_test-evidence.md
@@ -40,7 +40,7 @@ In regulated financial services environments, the inability to produce test evid
 ## Requirements
 
 * Automated test suites MUST be executed as part of the CI/CD pipeline for every pull request targeting a protected branch and every build that produces a deployable artefact
-* For Automated test execution results MUST be captured in a structured, machine-readable format (e.g., JUnit XML, CTRF) and stored as persistent artefacts linked to the triggering commit SHA, branch, pipeline run identifier, and timestamp or any other references to ensure traceability back to the intented release
+* For Automated test execution results MUST be captured in a structured, machine-readable format (e.g., JUnit XML, CTRF) and stored as persistent artefacts linked to the triggering commit SHA, branch, built artifact, pipeline run identifier, and timestamp or any other references to ensure traceability back to the intented release
 * Manual test evidence must be associated with the intented release for traceability, downstream gating and reporting.
 * Test evidence artefacts MUST be retained for a minimum period aligned with the organisation's regulatory audit retention policy; this period MUST NOT be less than the longest applicable regulatory retention requirement
 * Retained artefacts MUST be immutable after capture; they MUST NOT be modifiable, deletable, or re-runnable outside an approved and auditable exception process

--- a/docs/_mitigations/mi-18-dependency-curation.md
+++ b/docs/_mitigations/mi-18-dependency-curation.md
@@ -1,0 +1,50 @@
+---
+sequence: 18
+title: Dependency Curation
+layout: mitigation
+doc-status: Draft
+type: PREV
+nist-sp-800-53r5_references:
+  - sr-3   # SR-3 Supply Chain Controls and Processes
+mitigates:
+  - ri-10  # Dependency and Transitive Supply Chain Compromise
+related_mitigations:
+  - mi-9   # Component Inventory
+  - mi-7   # Vulnerability Scanning - Dependencies
+  - mi-12  # Deployment Gating
+---
+
+## Summary
+
+Dependency curation protects the organisation from open-source supply chain risk by enforcing automated, policy-driven governance on every open-source package before it enters development, build, or production use across the SDLC, much like a firewall.
+
+## Description
+
+Open-source and third-party packages are fetched continuously during development and CI — from public registries (npm, PyPI, Maven Central, RubyGems, NuGet, crates.io, and others), private feeds, and cached remote repositories. Without curationcontrolling  at the point of acquisition, malicious, tampered, vulnerable, or non-compliant packages can enter the estate before later controls (SBOM generation, vulnerability scanning, deployment gates) ever run.
+
+Dependency curation is the practice of controlling which package versions may be downloaded or resolved, evaluated against security and compliance policies at fetch time, and blocked or substituted before they are used in the SDLC. It operates as **pre-download OSS governance**: the first line of defense in the software supply chain timeline, distinct from post-build scanning or runtime detection.
+
+A curation process SHOULD cover all paths by which open-source dependencies enter the organisation, including developer workstations and IDEs, CI/CD dependency resolution, and organisation-managed binary and package repositories. Policies SHOULD be expressed in terms that security and legal teams can own (severity thresholds, license deny lists, allowlists, malicious-package blocks, immaturity or deprecation rules) while remaining enforceable automatically for developers.
+
+Curation complements [Component Inventory]({% link _mitigations/mi-9-component-inventory.md %}) (what is actually shipped) and [Vulnerability Scanning - Dependencies]({% link _mitigations/mi-7_vulnerability-scanning-dependencies.md %}) (known CVEs in code already in the pipeline). Curation reduces the chance that compromised or policy-violating packages enter the graph in the first place and help reduce fix effort that increase as release process progresses; inventory and scanning remain necessary for transitive visibility, drift, and newly disclosed vulnerabilities.
+
+## Requirements
+
+1. The organisation MUST define and maintain curation policies for open-source packages used in the SDLC, covering at minimum: known malicious or compromised packages, severity-based vulnerability thresholds, license compliance, and criteria for unapproved or restricted packages.
+2. Curation policies MUST be enforced automatically at package acquisition for all supported ecosystems and entry points used by the organisation (developer pulls, CI resolution, and organisation-managed package repositories), not solely by periodic manual review.
+3. Package repositories that proxy public or third-party registries MUST be connected to the curation control plane so that policy evaluation occurs before packages are cached or consumed downstream.
+4. Curation decisions MUST be logged and retained in accordance with the organisation's audit and record-retention requirements.
+
+## Examples & Commentary
+
+* **Pre-download vs post-build:** Blocking a typosquatted or malicious npm package at the remote repository prevents every developer and pipeline from caching it; relying only on a weekly SCA scan on `main` leaves a window where the package is already in lock files and build caches.
+* **License governance:** A policy that blocks copyleft or unknown-license packages at download prevents legal review debt and last-minute release blocks; pair with component inventory SBOMs for attestation of what shipped.
+* **Developer experience:** Integrate curation signals into CLI and IDE workflows so developers see policy outcomes at resolution time rather than only at failed pipeline stages.
+* **Relationship to deployment gating:** Curation at acquisition does not replace [Deployment Gating]({% link _mitigations/mi-12_deployment-gating.md %}) or provenance controls; it narrows what can enter the supply chain graph that those later controls must trust.
+
+## Links
+
+- [NIST SP 800-53r5 SR-3: Supply Chain Controls and Processes](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 SR-11: Component Authenticity](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SSDF SP 800-218](https://csrc.nist.gov/pubs/sp/800/218/final) (PO.3)
+- [OWASP SCVS](https://scvs.owasp.org/) (Guidance: Open Source Policy)


### PR DESCRIPTION
to enhance traceability requirements for automated test execution results by including 'built artifact' in the persistent artefacts description.

New mi-18 for dependencies curation, adding a mitigation for open-source dependencies by curating used packages