### PR TITLE
Add ri-12 business reputation risk and mi-19 version approval gating

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ risk_classification:
   RC: Regulatory and Compliance
   OP: Operational
   SEC: Security
+  BUS: Business
 
 mitigation_classification:
   PREV: Preventative

--- a/docs/_mitigations/mi-19_version-approval.md
+++ b/docs/_mitigations/mi-19_version-approval.md
@@ -1,0 +1,61 @@
+---
+sequence: 19
+title: Version Release Approval Gating
+layout: mitigation
+doc-status: Draft
+type: BUS
+
+mitigates:
+  - ri-12  # Business Reputation Risk from Non-Approved Software Version Releases
+related_mitigations:
+  - mi-12  # Deployment Gating
+
+---
+
+## Summary
+
+Version Release Approval Gating ensures that no software version is promoted to production without passing a defined approval workflow, enforced either by designated human approvers, automated policy checks, or a combination of both. It establishes a verifiable, auditable gate at the version level—distinct from per-deployment gates—that confirms the release candidate has satisfied all governance, quality, and risk requirements before any deployment is permitted.
+
+## Description
+
+Deployment gating ([MI-12]({% link _mitigations/mi-12_deployment-gating.md %})) controls whether an individual deployment job may proceed based on technical policy checks. Version Release Approval Gating operates at a higher level: it governs whether a named software version has received the organisational approval required to be released at all. A version may pass all automated deployment gates but still require explicit sign-off from a release manager, risk officer, or compliance stakeholder before it can be promoted from a candidate to an approved release.
+
+This distinction is critical in regulated financial services environments where change management frameworks require named human accountability for production releases, not merely automated technical policy satisfaction.
+
+The control supports two complementary approval mechanisms that may be used individually or in combination:
+
+**Manual Approval Workflows**
+Named approvers—such as a release manager, change advisory board (CAB) member, or risk officer—explicitly authorise a release candidate before it can proceed to any production deployment. The approval is recorded against the specific version, is timestamped and attributed to an identified individual, and must be obtained before any deployment pipeline for that version is unlocked. Approval workflows may be tiered, requiring different sets of approvers depending on the risk classification of the application or the scope of the change.
+
+**Automated Policy Checks**
+Policy-as-code evaluations assess the release candidate against a defined set of criteria that must all pass before the version is marked approved. These checks may include confirmation that all required test suites have executed and passed, that vulnerability findings are within approved thresholds, that security scan results have been attested, that mandatory review steps in the development workflow are complete, and that the release artefact matches a signed, verified build provenance record. Automated checks produce a structured approval record that can be used as audit evidence independently of human action.
+
+In either case, the approval state is recorded at the version level in a system of record (e.g., a release management platform, ITSM tool, or policy engine), and downstream deployment pipelines are blocked from proceeding until the required approval state is confirmed.
+
+## Requirements
+
+* Every software version intended for production MUST be subject to a defined approval workflow before any production deployment is initiated
+* The approval workflow MUST be enforced by the release pipeline; pipelines MUST verify the approval state of the target version before proceeding and MUST fail if approval is absent or has been revoked
+* Approval workflows MUST specify which approver roles or automated checks are required, differentiated by application risk classification where appropriate
+* Manual approvals MUST be attributed to a named individual, timestamped, and recorded in an auditable system of record
+* Automated approval checks MUST produce a structured, machine-readable result that is retained as part of the release record
+* Approval state MUST be bound to a specific, immutable version identifier (e.g., a signed artefact digest or tagged commit SHA); approval of one version MUST NOT be transferable to another
+* A documented emergency release process MUST exist for critical production incidents requiring deployment of a non-approved version. Emergency releases MUST require real-time approval from a named authority, MUST be time-bounded, MUST be logged with documented justification, and MUST trigger a post-incident governance review
+* Emergency release overrides MUST be reported to risk and compliance functions within a defined timeframe (e.g., next business day)
+* Approval records, including any overrides, MUST be retained for a period consistent with applicable regulatory requirements and the organisation's record-keeping policy
+* The set of required approval checks and approver roles MUST be reviewed at least annually, or following any material change in the application's risk profile, regulatory obligations, or technology stack
+
+## Examples & Commentary
+
+* **CAB-Gated Release:** For a high-criticality payment processing service, the release workflow requires approval from a release manager and a risk officer before the pipeline is permitted to deploy any build to production. The CAB review is documented in the ITSM system against the specific version tag, and the deployment pipeline queries the ITSM API to confirm approval state before executing any production deployment steps.
+
+* **Automated Policy-as-Code Approval:** For a lower-risk internal tooling service, a policy engine evaluates the release candidate against a ruleset: all unit and integration tests passed, no critical CVEs in dependencies, SAST scan completed with no new high findings, and build provenance attestation verified. When all checks pass, the policy engine issues a signed approval record that the deployment pipeline accepts as authorisation to proceed.
+
+* **Tiered Approval by Change Risk:** An organisation classifies changes as standard, significant, or emergency. Standard changes (low-risk, well-understood) may be approved by automated policy checks alone. Significant changes require a named release manager sign-off in addition to automated checks. Emergency changes require a senior technology officer approval, are time-limite, and trigger mandatory post-deployment review.
+
+* **Approval Binding to Artefact Digest:** To prevent version substitution attacks or accidental promotion of a different build, approval is recorded against the SHA-256 digest of the release artefact rather than a version label alone. The pipeline verifies both that the version label matches an approved record and that the artefact digest matches the digest recorded at approval time.
+
+* **Revocation:** If a vulnerability is discovered in a version that has already been approved but not yet fully deployed, the approval can be revoked in the system of record, and the deployment pipeline will reject further deployments of that version until a new approval is granted for a remediated build.
+
+## Links
+

--- a/docs/_risks/ri-12_business-reputation.md
+++ b/docs/_risks/ri-12_business-reputation.md
@@ -1,0 +1,49 @@
+---
+sequence: 12
+title: Business Reputation Risk from Non-Approved Software Version Releases
+layout: risk
+doc-status: Draft
+type: BUS
+related_risks:
+  - ri-8   # Unauthorised Change
+mitigations:
+  - mi-19  # Version Release Approval Gating
+  - mi-12  # Deployment Gating
+---
+## Summary
+
+Software versions that have not completed the required approval, validation, or governance process but are released to production, might cause customer-facing defects, regulatory non-compliance, or security vulnerabilities that erode market confidence, damage the institution's reputation, and trigger stakeholder backlash.
+Additionally, versions that are misaligned with product direction or has features that conflict with the companies broader strategic goals or marketing messages might harm strategic goals.
+
+As a result, for companies that are publicly traded in the US (or falls under global equivalents like UK SOX), a formal version release approval process is one of the most critical elements of a Sarbanes-Oxley (SOX) audit: 
+- SOC 2 Type II - CC8.1 (Change Management) - Requires organizations to authorize, design, develop, test, **approval**, and implement system changes to prevent unauthorized modifications and maintain integrity.
+
+
+## Description
+
+Financial institutions operate under strict change management and release governance frameworks that require software versions to pass defined quality gates, risk assessments, security reviews, and approval checkpoints before reaching production. When software is released outside this approval process—whether through pipeline misconfigurations, governance bypasses, emergency shortcuts, or deliberate circumvention—the resulting production incidents expose the institution to reputational harm that can outlast the technical failure itself.
+
+Non-approved releases may carry untested changes, unresolved vulnerabilities, broken integrations, or incomplete compliance controls. Even when the technical impact is contained quickly, the public disclosure of a release governance failure signals to customers, regulators, and counterparties that the institution's internal controls cannot be relied upon. In markets where trust is foundational, this signal alone carries lasting commercial consequences.
+
+- **Release pipeline bypass** — Changes deployed to production without passing mandatory approval gates, peer review, or security scanning due to misconfigured pipelines or deliberate shortcuts
+- **Emergency hotfix without governance** — Urgent fixes applied directly to production outside normal change management, introducing untested code that causes new defects or exposes existing vulnerabilities
+- **Incorrect version promotion** — A build artefact from a non-approved branch or an earlier rejected release candidate is accidentally promoted to production, carrying known defects or previously rejected functionality
+- **Shadow releases and feature flags** — Partial feature activations or configuration changes that effectively constitute a release are made without formal approval, bypassing governance controls
+- **Rollback to a non-approved state** — Incident response rollbacks that restore a production version that predates the current approval baseline, reintroducing previously remediated defects or compliance gaps
+
+### Consequences
+
+* **Customer-Facing Service Disruption:** Non-approved releases carrying defects or incompatible changes can cause transaction failures, incorrect account balances, broken payment flows, or application unavailability, directly affecting customers and triggering complaints, churn, and media coverage.
+
+* **Regulatory Censure and Enforcement Action:** Financial regulators (e.g., FCA, OCC, FINRA, ECB) require evidence of robust change management. Release of non-approved software signals a breakdown in internal controls and can result in formal findings, remediation orders, increased supervisory scrutiny, or fines.
+
+* **Erosion of Customer and Counterparty Trust:** Public incidents attributed to inadequate release governance—particularly those involving financial errors or data exposure—damage the institution's reputation with retail customers, institutional counterparties, and rating agencies, with effects that persist long after the technical incident is resolved.
+
+* **Reputational Contagion Across Product Lines:** A high-profile release failure in one product or channel can cast doubt on the reliability of the institution's entire technology estate, affecting products that were not involved in the incident.
+
+
+* **Internal Confidence and Talent Impact:** Sustained reputational damage and visible governance failures can affect the institution's ability to attract and retain technology talent, particularly in competitive engineering markets where employer brand matters.
+
+* **Legal Liability:** Customers or counterparties suffering financial losses as a result of a non-approved release may pursue civil claims, compounding reputational damage with litigation costs and adverse judgments.
+
+## Links


### PR DESCRIPTION
Supersedes #68 — re-applies the same content under a DCO-signed commit so it can be merged. Content is identical; original author Carmit Hershman preserved as co-author.

- Adds `BUS` (Business) risk classification to `_config.yml`
- Adds **ri-12 Business Reputation Risk from Non-Approved Software Version Releases** (SOX / SOC 2 CC8.1 framing), related to ri-8, mitigated by mi-12 and mi-19
- Adds **mi-19 Version Release Approval Gating**: version-level approval (manual workflow, automated policy-as-code, or both), distinct from the per-deployment gating in mi-12

## Test plan

- [x] DCO check passes
- [x] Lint / readiness checks pass
- [ ] ri-12 and mi-19 render correctly in Jekyll preview
- [ ] Close #68 once merged