### PR TITLE
Make catalogue filters config-driven and cross-linked

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,14 +5,25 @@ release-date: 2025-09-23
 baseurl: "/SDLC-Controls-Framework"
 
 risk_classification:
-  RC: Regulatory and Compliance
   OP: Operational
   SEC: Security
+  RC: Regulatory and Compliance
   BUS: Business
 
 mitigation_classification:
   PREV: Preventative
   DET: Detective
+
+# Bootstrap Icons class for each classification code, used by the catalogue
+# headings and filter checkboxes. Adding a new code above requires adding the
+# matching icon here.
+category_icons:
+  OP: bi-person-fill-gear
+  SEC: bi-bug-fill
+  RC: bi-clipboard2-check-fill
+  BUS: bi-briefcase-fill
+  PREV: bi-lock-fill
+  DET: bi-eye-fill
 
 document_status:
   - name: Pre-Draft

--- a/docs/_includes/catalogue.html
+++ b/docs/_includes/catalogue.html
@@ -52,7 +52,7 @@
                                             <div class="form-check form-check-sm mb-1">
                                                 <input class="form-check-input category-checkbox" type="checkbox" value="{{ code }}" id="cat-{{ code }}" data-type="risk">
                                                 <label class="form-check-label small" for="cat-{{ code }}">
-                                                    <i class="{{ site.category_icons[code] }} me-1"></i>{{ label }}
+                                                    <i class="bi {{ site.category_icons[code] }} me-1"></i>{{ label }}
                                                 </label>
                                             </div>
                                             {% endfor %}
@@ -67,7 +67,7 @@
                                             <div class="form-check form-check-sm mb-1">
                                                 <input class="form-check-input category-checkbox" type="checkbox" value="{{ code }}" id="cat-{{ code }}" data-type="mitigation">
                                                 <label class="form-check-label small" for="cat-{{ code }}">
-                                                    <i class="{{ site.category_icons[code] }} me-1"></i>{{ label }}
+                                                    <i class="bi {{ site.category_icons[code] }} me-1"></i>{{ label }}
                                                 </label>
                                             </div>
                                             {% endfor %}
@@ -115,7 +115,7 @@
                       <div class="mb-4">
                           <div class="d-flex justify-content-between align-items-center mb-2">
                               <h3 class="h5 mb-0 text-primary">
-                                  {% if category_icon %}<i class="{{ category_icon }} me-2"></i>{% endif %}
+                                  {% if category_icon %}<i class="bi {{ category_icon }} me-2"></i>{% endif %}
                                   {{ site.risk_classification[risk_group.name] }}
                               </h3>
                               <span class="badge bg-primary">{{ risk_group.items | size }} risks</span>
@@ -124,7 +124,7 @@
                               {% assign sorted_risks = risk_group.items | sort: "sequence" %}
                               {% for risk in sorted_risks %}
                               {% assign risk_status = risk['doc-status'] | default: '' %}
-                              <div class="col-12 risk-item" data-title="{{ risk.title | downcase }}" data-content="{{ risk.content | strip_html | strip_newlines | downcase }}" data-status="{{ risk_status }}">
+                              <div class="col-12 risk-item" data-id="ri-{{ risk.sequence }}" data-title="{{ risk.title | downcase }}" data-content="{{ risk.content | strip_html | strip_newlines | downcase }}" data-status="{{ risk_status }}">
                                   <div class="card border-start border-primary border-3 h-100 card-hover" onclick="window.location.href='{{ site.baseurl }}{{ risk.id }}.html'" style="cursor: pointer;">
                                       <div class="card-body py-2">
                                           <div class="d-flex justify-content-between align-items-start">
@@ -197,7 +197,7 @@
                       <div class="mb-4">
                           <div class="d-flex justify-content-between align-items-center mb-2">
                               <h3 class="h5 mb-0 text-success">
-                                  {% if category_icon %}<i class="{{ category_icon }} me-2"></i>{% endif %}
+                                  {% if category_icon %}<i class="bi {{ category_icon }} me-2"></i>{% endif %}
                                   {{ site.mitigation_classification[mitigation_group.name] }}
                               </h3>
                               <span class="badge bg-success">{{ mitigation_group.items | size }} mitigations</span>
@@ -206,7 +206,7 @@
                               {% assign sorted_mitigations = mitigation_group.items | sort: "sequence" %}
                               {% for mitigation in sorted_mitigations %}
                               {% assign mitigation_status = mitigation['doc-status'] | default: '' %}
-                              <div class="col-12 mitigation-item" data-title="{{ mitigation.title | downcase }}" data-content="{{ mitigation.content | strip_html | strip_newlines | downcase }}" data-status="{{ mitigation_status }}">
+                              <div class="col-12 mitigation-item" data-mitigates="{{ mitigation.mitigates | join: ' ' }}" data-title="{{ mitigation.title | downcase }}" data-content="{{ mitigation.content | strip_html | strip_newlines | downcase }}" data-status="{{ mitigation_status }}">
                                   <div class="card border-start border-success border-3 h-100 card-hover" onclick="window.location.href='{{ site.baseurl }}{{ mitigation.id }}.html'" style="cursor: pointer;">
                                       <div class="card-body py-2">
                                           <div class="d-flex justify-content-between align-items-start">
@@ -359,38 +359,81 @@ document.addEventListener('DOMContentLoaded', function() {
         const selectedCategories = Array.from(categoryCheckboxes)
             .filter(checkbox => checkbox.checked)
             .map(checkbox => checkbox.value);
-        
+        // Category checkboxes are scoped by data-type — a ticked SEC must
+        // only constrain risks, a ticked PREV only constrain mitigations,
+        // otherwise the cross-type filter zeroes out one panel.
+        const selectedCategoriesByType = {
+            risk: Array.from(categoryCheckboxes)
+                .filter(cb => cb.checked && cb.dataset.type === 'risk')
+                .map(cb => cb.value),
+            mitigation: Array.from(categoryCheckboxes)
+                .filter(cb => cb.checked && cb.dataset.type === 'mitigation')
+                .map(cb => cb.value),
+        };
+
         let riskCount = 0;
         let mitigationCount = 0;
-        
+
         const selectedStatus = statusFilter.value;
 
-        // Filter items
-        ['risk', 'mitigation'].forEach(type => {
-            document.querySelectorAll(`.${type}-item`).forEach(item => {
-                const title = item.getAttribute('data-title') || '';
-                const content = item.getAttribute('data-content') || '';
-                const itemStatus = item.getAttribute('data-status') || '';
-                const parentSection = item.closest('[data-category]');
-                const itemCategory = parentSection?.getAttribute('data-category') || '';
+        // Pass 1: evaluate each item against its own filters (no
+        // cross-linkage yet) and remember the decision.
+        const ownMatch = (item, type) => {
+            const title = item.getAttribute('data-title') || '';
+            const content = item.getAttribute('data-content') || '';
+            const itemStatus = item.getAttribute('data-status') || '';
+            const itemCategory = item.closest('[data-category]')?.getAttribute('data-category') || '';
+            const cats = selectedCategoriesByType[type];
+            return (!searchTerm || title.includes(searchTerm) || content.includes(searchTerm))
+                && (!selectedType || selectedType === type)
+                && (cats.length === 0 || cats.includes(itemCategory))
+                && (!selectedStatus || itemStatus === selectedStatus);
+        };
 
-                const matchesSearch = !searchTerm || title.includes(searchTerm) || content.includes(searchTerm);
-                const matchesType = !selectedType || selectedType === type;
-                const matchesCategory = selectedCategories.length === 0 || selectedCategories.includes(itemCategory);
-                const matchesStatus = !selectedStatus || itemStatus === selectedStatus;
+        const riskDecisions = [];
+        const visibleRiskIds = new Set();
+        document.querySelectorAll('.risk-item').forEach(item => {
+            const ok = ownMatch(item, 'risk');
+            const id = item.getAttribute('data-id');
+            riskDecisions.push({ item, ownOk: ok, id });
+            if (ok && id) visibleRiskIds.add(id);
+        });
 
-                const isVisible = matchesSearch && matchesType && matchesCategory && matchesStatus;
-                item.style.display = isVisible ? 'block' : 'none';
-                
-                // Count visible items
-                if (isVisible) {
-                    if (type === 'risk') {
-                        riskCount++;
-                    } else {
-                        mitigationCount++;
-                    }
-                }
-            });
+        const mitDecisions = [];
+        const targetedRiskIds = new Set();
+        document.querySelectorAll('.mitigation-item').forEach(item => {
+            const ok = ownMatch(item, 'mitigation');
+            const mitigates = (item.getAttribute('data-mitigates') || '').split(/\s+/).filter(Boolean);
+            mitDecisions.push({ item, ownOk: ok, mitigates });
+            if (ok) mitigates.forEach(id => targetedRiskIds.add(id));
+        });
+
+        // Pass 2: apply bidirectional cross-linkage. Each side narrows the
+        // other when (a) it has filtered down below its full set and (b)
+        // it still has at least one match (so a search with no hits on
+        // one side doesn't wipe out the other side too).
+        const risksNarrowed = visibleRiskIds.size > 0
+            && visibleRiskIds.size < riskDecisions.length;
+        const mitsOwnVisibleCount = mitDecisions.filter(d => d.ownOk).length;
+        const mitsNarrowed = mitsOwnVisibleCount > 0
+            && mitsOwnVisibleCount < mitDecisions.length;
+
+        riskDecisions.forEach(({ item, ownOk, id }) => {
+            let visible = ownOk;
+            if (visible && mitsNarrowed && selectedType !== 'risk') {
+                visible = targetedRiskIds.has(id);
+            }
+            item.style.display = visible ? 'block' : 'none';
+            if (visible) riskCount++;
+        });
+
+        mitDecisions.forEach(({ item, ownOk, mitigates }) => {
+            let visible = ownOk;
+            if (visible && risksNarrowed && selectedType !== 'mitigation') {
+                visible = mitigates.some(id => visibleRiskIds.has(id));
+            }
+            item.style.display = visible ? 'block' : 'none';
+            if (visible) mitigationCount++;
         });
         
         // Update category section visibility and badges
@@ -399,8 +442,9 @@ document.addEventListener('DOMContentLoaded', function() {
             const sectionType = section.getAttribute('data-type');
             const visibleItems = section.querySelectorAll(`.${sectionType}-item:not([style*="display: none"])`);
             
-            const shouldShow = (!selectedType || selectedType === sectionType) && 
-                             (selectedCategories.length === 0 || selectedCategories.includes(categoryType)) &&
+            const sectionCats = selectedCategoriesByType[sectionType] || [];
+            const shouldShow = (!selectedType || selectedType === sectionType) &&
+                             (sectionCats.length === 0 || sectionCats.includes(categoryType)) &&
                              visibleItems.length > 0;
             
             const container = section.closest('.mb-4');

--- a/docs/_includes/catalogue.html
+++ b/docs/_includes/catalogue.html
@@ -46,41 +46,31 @@
                                             <div class="small text-muted fw-bold mb-2">
                                                 <i class="bi bi-asterisk me-1"></i>Risks
                                             </div>
+                                            {% for entry in site.risk_classification %}
+                                            {% assign code = entry[0] %}
+                                            {% assign label = entry[1] %}
                                             <div class="form-check form-check-sm mb-1">
-                                                <input class="form-check-input category-checkbox" type="checkbox" value="OP" id="cat-OP" data-type="risk">
-                                                <label class="form-check-label small" for="cat-OP">
-                                                    <i class="bi bi-person-fill-gear me-1"></i>Operational
+                                                <input class="form-check-input category-checkbox" type="checkbox" value="{{ code }}" id="cat-{{ code }}" data-type="risk">
+                                                <label class="form-check-label small" for="cat-{{ code }}">
+                                                    <i class="{{ site.category_icons[code] }} me-1"></i>{{ label }}
                                                 </label>
                                             </div>
-                                            <div class="form-check form-check-sm mb-1">
-                                                <input class="form-check-input category-checkbox" type="checkbox" value="SEC" id="cat-SEC" data-type="risk">
-                                                <label class="form-check-label small" for="cat-SEC">
-                                                    <i class="bi bi-bug-fill me-1"></i>Security
-                                                </label>
-                                            </div>
-                                            <div class="form-check form-check-sm mb-0">
-                                                <input class="form-check-input category-checkbox" type="checkbox" value="RC" id="cat-RC" data-type="risk">
-                                                <label class="form-check-label small" for="cat-RC">
-                                                    <i class="bi bi-clipboard2-check-fill me-1"></i>Regulatory
-                                                </label>
-                                            </div>
+                                            {% endfor %}
                                         </div>
                                         <div class="col-6">
                                             <div class="small text-muted fw-bold mb-2">
                                                 <i class="bi bi-shield-shaded me-1"></i>Mitigations
                                             </div>
+                                            {% for entry in site.mitigation_classification %}
+                                            {% assign code = entry[0] %}
+                                            {% assign label = entry[1] %}
                                             <div class="form-check form-check-sm mb-1">
-                                                <input class="form-check-input category-checkbox" type="checkbox" value="PREV" id="cat-PREV" data-type="mitigation">
-                                                <label class="form-check-label small" for="cat-PREV">
-                                                    <i class="bi bi-lock-fill me-1"></i>Preventative
+                                                <input class="form-check-input category-checkbox" type="checkbox" value="{{ code }}" id="cat-{{ code }}" data-type="mitigation">
+                                                <label class="form-check-label small" for="cat-{{ code }}">
+                                                    <i class="{{ site.category_icons[code] }} me-1"></i>{{ label }}
                                                 </label>
                                             </div>
-                                            <div class="form-check form-check-sm mb-0">
-                                                <input class="form-check-input category-checkbox" type="checkbox" value="DET" id="cat-DET" data-type="mitigation">
-                                                <label class="form-check-label small" for="cat-DET">
-                                                    <i class="bi bi-eye-fill me-1"></i>Detective
-                                                </label>
-                                            </div>
+                                            {% endfor %}
                                         </div>
                                     </div>
                                 </div>
@@ -117,19 +107,15 @@
                 <div class="card-body">
                     <p class="text-muted mb-4">Identify potential risks in your AI implementation across operational, security, and regulatory dimensions.</p>
                     
-                    {% for order in page.risk_order %}
+                    {% for entry in site.risk_classification %}
+                      {% assign order = entry[0] %}
                       {% assign risk_group = site.risks | group_by: "type" | where: "name", order | first %}
                       {% if risk_group %}
+                      {% assign category_icon = site.category_icons[order] %}
                       <div class="mb-4">
                           <div class="d-flex justify-content-between align-items-center mb-2">
                               <h3 class="h5 mb-0 text-primary">
-                                  {% if order == 'OP' %}
-                                      <i class="bi bi-person-fill-gear me-2"></i>
-                                  {% elsif order == 'SEC' %}
-                                      <i class="bi bi-bug-fill me-2"></i>
-                                  {% elsif order == 'RC' %}
-                                      <i class="bi bi-clipboard2-check-fill me-2"></i>
-                                  {% endif %}
+                                  {% if category_icon %}<i class="{{ category_icon }} me-2"></i>{% endif %}
                                   {{ site.risk_classification[risk_group.name] }}
                               </h3>
                               <span class="badge bg-primary">{{ risk_group.items | size }} risks</span>
@@ -203,17 +189,15 @@
                 <div class="card-body">
                     <p class="text-muted mb-4">Discover preventative and detective controls to mitigate identified risks in your AI systems.</p>
                     
-                    {% for order in page.mitigation_order %}
+                    {% for entry in site.mitigation_classification %}
+                      {% assign order = entry[0] %}
                       {% assign mitigation_group = site.mitigations | group_by: "type" | where: "name", order | first %}
                       {% if mitigation_group %}
+                      {% assign category_icon = site.category_icons[order] %}
                       <div class="mb-4">
                           <div class="d-flex justify-content-between align-items-center mb-2">
                               <h3 class="h5 mb-0 text-success">
-                                  {% if order == 'PREV' %}
-                                      <i class="bi bi-lock-fill me-2"></i>
-                                  {% elsif order == 'DET' %}
-                                      <i class="bi bi-eye-fill me-2"></i>
-                                  {% endif %}
+                                  {% if category_icon %}<i class="{{ category_icon }} me-2"></i>{% endif %}
                                   {{ site.mitigation_classification[mitigation_group.name] }}
                               </h3>
                               <span class="badge bg-success">{{ mitigation_group.items | size }} mitigations</span>

--- a/docs/_mitigations/mi-19_version-approval.md
+++ b/docs/_mitigations/mi-19_version-approval.md
@@ -3,7 +3,7 @@ sequence: 19
 title: Version Release Approval Gating
 layout: mitigation
 doc-status: Draft
-type: BUS
+type: PREV
 
 mitigates:
   - ri-12  # Business Reputation Risk from Non-Approved Software Version Releases

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,13 +2,6 @@
 layout: index
 title: "FINOS SDLC³- SDLC Common Controls Catalog"
 subtitle: "A comprehensive collection of risks and control that support the regulated software development lifecycle"
-risk_order:
-  - OP
-  - SEC
-  - RC
-mitigation_order:
-  - PREV
-  - DET
 ---
 
 In today’s highly regulated technology landscape, the Software Development Life Cycle (SDLC) must be executed with rigor, discipline, and with increasing focus on compliance. Organizations are increasingly required to demonstrate adherence to governance frameworks, regulatory standards, and internal risk management policies.


### PR DESCRIPTION
Two related improvements to the catalogue page, bundled so they land together.

## 1. Config-driven classifications

The filter checkboxes, catalogue section headings and their icons were hardcoded to OP/SEC/RC/PREV/DET, so the BUS classification added in #70 was invisible in the UI — ri-12 wouldn't render and there was no BUS filter checkbox. mi-19 hit the same problem with an incorrect `type: BUS` (a risk classification, not a mitigation type).

- `_config.yml` — add `category_icons` map; reorder `risk_classification` to OP/SEC/RC/BUS to preserve display order
- `_includes/catalogue.html` — iterate `site.risk_classification` / `site.mitigation_classification` for both the rendering loops and the filter checkboxes; icons come from `site.category_icons`; drop the hardcoded `if/elsif` chains
- `index.md` — remove redundant `risk_order` / `mitigation_order` front-matter (order now follows `_config.yml`)
- `mi-19_version-approval.md` — change `type: BUS` → `type: PREV`. BUS describes the kind of damage (risk); mitigation type describes how the control works. mi-19 gates releases → preventative

After this, adding a new classification only requires a new entry in `risk_classification` (or `mitigation_classification`) and `category_icons` — no HTML edits.

## 2. Cross-linked filters and icon-rendering fix

- Add the missing `bi` Bootstrap Icons class so the icons wired up in part 1 actually render
- Scope category checkboxes by `data-type` — previously, ticking e.g. SEC also constrained the mitigation panel and zeroed it out
- Filtering one panel now narrows the other: visible risks restrict mitigations to those that mitigate them, and visible mitigations restrict risks to those they mitigate (implemented via new `data-id` / `data-mitigates` attributes and a two-pass filter)

## Test plan

- [ ] DCO check passes
- [ ] Readiness check passes
- [ ] ri-12 renders in the Risk Catalogue under a new **Business** heading with the briefcase icon
- [ ] mi-19 renders in the Mitigation Catalogue under **Preventative**
- [ ] Classification icons render in both the headings and the filter checkboxes
- [ ] Filter sidebar shows a **Business** checkbox under Risks; toggling it isolates ri-12
- [ ] PREV/DET filter still works for mitigations
- [ ] Ticking a risk category (e.g. SEC) narrows the mitigation panel to mitigations linked to visible SEC risks (no longer zeroes it out)
- [ ] Ticking a mitigation category (e.g. PREV) narrows the risk panel to risks mitigated by visible PREV mitigations
- [ ] Searching for a risk title narrows the mitigation panel to mitigations that mitigate matching risks