### PR TITLE
Add SDLC phase classification and catalogue phase filter

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,6 +14,16 @@ mitigation_classification:
   PREV: Preventative
   DET: Detective
 
+# SDLC phase at which a mitigation primarily operates. LIFECYCLE is the
+# cross-cutting bucket for governance/process controls that are not tied to a
+# single phase. Used by the catalogue phase filter.
+phase_classification:
+  CODE: Code
+  BUILD: Build
+  RELEASE: Release
+  RUNTIME: Runtime
+  LIFECYCLE: Lifecycle
+
 # Bootstrap Icons class for each classification code, used by the catalogue
 # headings and filter checkboxes. Adding a new code above requires adding the
 # matching icon here.
@@ -24,6 +34,11 @@ category_icons:
   BUS: bi-briefcase-fill
   PREV: bi-lock-fill
   DET: bi-eye-fill
+  CODE: bi-code-slash
+  BUILD: bi-hammer
+  RELEASE: bi-rocket-takeoff-fill
+  RUNTIME: bi-play-circle-fill
+  LIFECYCLE: bi-arrow-repeat
 
 document_status:
   - name: Pre-Draft

--- a/docs/_includes/catalogue.html
+++ b/docs/_includes/catalogue.html
@@ -16,11 +16,11 @@
                 <!-- Filter content that can be collapsed -->
                 <div class="filter-content" id="filterContent" style="display: none;">
                     <div class="row g-3">
-                        <div class="col-md-3">
+                        <div class="col-md-4">
                             <label for="searchInput" class="form-label fw-bold">Search</label>
                             <input type="text" class="form-control" id="searchInput" placeholder="Search risks and mitigations by title or content...">
                         </div>
-                        <div class="col-md-2">
+                        <div class="col-md-3">
                             <label for="typeFilter" class="form-label fw-bold">Filter by Type</label>
                             <select class="form-select" id="typeFilter">
                                 <option value="">All Types</option>
@@ -28,7 +28,7 @@
                                 <option value="mitigation">Mitigations Only</option>
                             </select>
                         </div>
-                        <div class="col-md-2">
+                        <div class="col-md-3">
                             <label for="statusFilter" class="form-label fw-bold">Filter by Status</label>
                             <select class="form-select" id="statusFilter">
                                 <option value="">All Statuses</option>
@@ -37,7 +37,13 @@
                                 {% endfor %}
                             </select>
                         </div>
-                        <div class="col-md-3">
+                        <div class="col-md-2">
+                            <label class="form-label fw-bold">&nbsp;</label>
+                            <button type="button" class="btn btn-outline-secondary w-100" id="resetFilters">
+                                Reset
+                            </button>
+                        </div>
+                        <div class="col-md-6">
                             <label class="form-label fw-bold">Filter by Category</label>
                             <div class="card border">
                                 <div class="card-body p-2">
@@ -76,7 +82,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-md-3">
+                        <div class="col-md-6">
                             <label class="form-label fw-bold">Filter by Phase</label>
                             <div class="card border">
                                 <div class="card-body p-2">
@@ -87,7 +93,7 @@
                                         {% for entry in site.phase_classification %}
                                         {% assign code = entry[0] %}
                                         {% assign label = entry[1] %}
-                                        <div class="col-6">
+                                        <div class="col-6 col-lg-4">
                                             <div class="form-check form-check-sm mb-1">
                                                 <input class="form-check-input phase-checkbox" type="checkbox" value="{{ code }}" id="phase-{{ code }}">
                                                 <label class="form-check-label small" for="phase-{{ code }}">
@@ -99,12 +105,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-md-2">
-                            <label class="form-label fw-bold">&nbsp;</label>
-                            <button type="button" class="btn btn-outline-secondary w-100" id="resetFilters">
-                                Reset
-                            </button>
                         </div>
                     </div>
                 </div>

--- a/docs/_includes/catalogue.html
+++ b/docs/_includes/catalogue.html
@@ -76,6 +76,30 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-md-3">
+                            <label class="form-label fw-bold">Filter by Phase</label>
+                            <div class="card border">
+                                <div class="card-body p-2">
+                                    <div class="small text-muted fw-bold mb-2">
+                                        <i class="bi bi-diagram-3-fill me-1"></i>Mitigation Phase
+                                    </div>
+                                    <div class="row g-2">
+                                        {% for entry in site.phase_classification %}
+                                        {% assign code = entry[0] %}
+                                        {% assign label = entry[1] %}
+                                        <div class="col-6">
+                                            <div class="form-check form-check-sm mb-1">
+                                                <input class="form-check-input phase-checkbox" type="checkbox" value="{{ code }}" id="phase-{{ code }}">
+                                                <label class="form-check-label small" for="phase-{{ code }}">
+                                                    <i class="bi {{ site.category_icons[code] }} me-1"></i>{{ label }}
+                                                </label>
+                                            </div>
+                                        </div>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="col-md-2">
                             <label class="form-label fw-bold">&nbsp;</label>
                             <button type="button" class="btn btn-outline-secondary w-100" id="resetFilters">
@@ -206,7 +230,7 @@
                               {% assign sorted_mitigations = mitigation_group.items | sort: "sequence" %}
                               {% for mitigation in sorted_mitigations %}
                               {% assign mitigation_status = mitigation['doc-status'] | default: '' %}
-                              <div class="col-12 mitigation-item" data-mitigates="{{ mitigation.mitigates | join: ' ' }}" data-title="{{ mitigation.title | downcase }}" data-content="{{ mitigation.content | strip_html | strip_newlines | downcase }}" data-status="{{ mitigation_status }}">
+                              <div class="col-12 mitigation-item" data-phase="{{ mitigation.phase }}" data-mitigates="{{ mitigation.mitigates | join: ' ' }}" data-title="{{ mitigation.title | downcase }}" data-content="{{ mitigation.content | strip_html | strip_newlines | downcase }}" data-status="{{ mitigation_status }}">
                                   <div class="card border-start border-success border-3 h-100 card-hover" onclick="window.location.href='{{ site.baseurl }}{{ mitigation.id }}.html'" style="cursor: pointer;">
                                       <div class="card-body py-2">
                                           <div class="d-flex justify-content-between align-items-start">
@@ -371,6 +395,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 .map(cb => cb.value),
         };
 
+        // Phase is a property of mitigations only; it narrows the mitigation
+        // panel directly and the risk panel indirectly via cross-linkage.
+        const selectedPhases = Array.from(document.querySelectorAll('.phase-checkbox'))
+            .filter(cb => cb.checked)
+            .map(cb => cb.value);
+
         let riskCount = 0;
         let mitigationCount = 0;
 
@@ -384,10 +414,14 @@ document.addEventListener('DOMContentLoaded', function() {
             const itemStatus = item.getAttribute('data-status') || '';
             const itemCategory = item.closest('[data-category]')?.getAttribute('data-category') || '';
             const cats = selectedCategoriesByType[type];
+            const phaseOk = type !== 'mitigation'
+                || selectedPhases.length === 0
+                || selectedPhases.includes(item.getAttribute('data-phase') || '');
             return (!searchTerm || title.includes(searchTerm) || content.includes(searchTerm))
                 && (!selectedType || selectedType === type)
                 && (cats.length === 0 || cats.includes(itemCategory))
-                && (!selectedStatus || itemStatus === selectedStatus);
+                && (!selectedStatus || itemStatus === selectedStatus)
+                && phaseOk;
         };
 
         const riskDecisions = [];
@@ -546,6 +580,11 @@ document.addEventListener('DOMContentLoaded', function() {
             checkbox.checked = false;
             checkbox.disabled = false;
         });
+
+        // Uncheck phase checkboxes
+        document.querySelectorAll('.phase-checkbox').forEach(checkbox => {
+            checkbox.checked = false;
+        });
         
         // Reset column opacity
         document.querySelectorAll('.col-6').forEach(column => {
@@ -601,8 +640,8 @@ document.addEventListener('DOMContentLoaded', function() {
     updateCategoryOptions();
     applyCatalogueStates();
     
-    // Add initial event listeners to category checkboxes
-    document.querySelectorAll('.category-checkbox').forEach(checkbox => {
+    // Add initial event listeners to category and phase checkboxes
+    document.querySelectorAll('.category-checkbox, .phase-checkbox').forEach(checkbox => {
         checkbox.addEventListener('change', filterItems);
     });
     

--- a/docs/_mitigations/mi-10_secret-detection.md
+++ b/docs/_mitigations/mi-10_secret-detection.md
@@ -4,6 +4,7 @@ title: Secret Detection
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: CODE
 nist-sp-800-53r5_references:
   - ra-5   # RA-5 Vulnerability Monitoring And Scanning
   - ia-5   # IA-5 Authenticator Management

--- a/docs/_mitigations/mi-11_vulnerability-remediation-slas.md
+++ b/docs/_mitigations/mi-11_vulnerability-remediation-slas.md
@@ -4,6 +4,7 @@ title: Vulnerability Remediation SLAs
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: LIFECYCLE
 nist-sp-800-53r5_references:
   - ra-5   # RA-5 Vulnerability Monitoring And Scanning
   - si-2   # SI-2 Flaw Remediation

--- a/docs/_mitigations/mi-12_deployment-gating.md
+++ b/docs/_mitigations/mi-12_deployment-gating.md
@@ -4,6 +4,7 @@ title: Deployment Gating
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: RELEASE
 nist-sp-800-53r5_references:
   - ra-5   # RA-5 Vulnerability Monitoring And Scanning
   - si-2   # SI-2 Flaw Remediation

--- a/docs/_mitigations/mi-13-system-ownership.md
+++ b/docs/_mitigations/mi-13-system-ownership.md
@@ -4,6 +4,7 @@ title: System Inventory
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: LIFECYCLE
 nist-sp-800-53r5_references:
   - pm-5   # PM-5 System Inventory
 mitigates:

--- a/docs/_mitigations/mi-14_test-evidence.md
+++ b/docs/_mitigations/mi-14_test-evidence.md
@@ -4,6 +4,7 @@ title: Test Evidence Retention
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: BUILD
 chain:
   - testing-assurance
 nist-sp-800-53r5_references:

--- a/docs/_mitigations/mi-15_testing-requirements.md
+++ b/docs/_mitigations/mi-15_testing-requirements.md
@@ -4,6 +4,7 @@ title: Testing Requirements
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: LIFECYCLE
 chain:
   - testing-assurance
 nist-sp-800-53r5_references:

--- a/docs/_mitigations/mi-16_test-execution.md
+++ b/docs/_mitigations/mi-16_test-execution.md
@@ -4,6 +4,7 @@ title: Test Execution and Sign-Off
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: BUILD
 chain:
   - testing-assurance
 nist-sp-800-53r5_references:

--- a/docs/_mitigations/mi-17_service-dependency-control.md
+++ b/docs/_mitigations/mi-17_service-dependency-control.md
@@ -4,6 +4,7 @@ title: Service Dependency Control
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: RUNTIME
 nist-sp-800-53r5_references:
   - cm-8   # CM-8 System Component Inventory
   - si-4   # SI-4 System Monitoring

--- a/docs/_mitigations/mi-19_version-approval.md
+++ b/docs/_mitigations/mi-19_version-approval.md
@@ -4,6 +4,7 @@ title: Version Release Approval Gating
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: RELEASE
 
 mitigates:
   - ri-12  # Business Reputation Risk from Non-Approved Software Version Releases

--- a/docs/_mitigations/mi-2_content-addressable-identities.md
+++ b/docs/_mitigations/mi-2_content-addressable-identities.md
@@ -4,6 +4,7 @@ title: Content Addressable Identities
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: BUILD
 nist-sp-800-53r5_references:
   - si-7   # SI-7 Software, Firmware, And Information Integrity
   - sa-10  # SA-10 Developer Configuration Management

--- a/docs/_mitigations/mi-3_software-artifact-provenance.md
+++ b/docs/_mitigations/mi-3_software-artifact-provenance.md
@@ -4,6 +4,7 @@ title: Software Artifact Provenance
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: BUILD
 nist-sp-800-53r5_references:
   - sa-10  # SA-10 Developer Configuration Management
   - sa-11  # SA-11 Developer Testing And Evaluation

--- a/docs/_mitigations/mi-4_requirements.md
+++ b/docs/_mitigations/mi-4_requirements.md
@@ -4,6 +4,7 @@ title: Requirements Management
 layout: mitigation
 doc-status: Pre-Draft
 type: PREV
+phase: LIFECYCLE
 mitigates:
 related_mitigations:
 ---

--- a/docs/_mitigations/mi-5_vulnerability-scanning-sast.md
+++ b/docs/_mitigations/mi-5_vulnerability-scanning-sast.md
@@ -4,6 +4,7 @@ title: Vulnerability Scanning - SAST
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: CODE
 nist-sp-800-53r5_references:
   - ra-5   # RA-5 Vulnerability Monitoring And Scanning
   - sa-11  # SA-11 Developer Testing And Evaluation

--- a/docs/_mitigations/mi-6_vulnerability-scanning-dast.md
+++ b/docs/_mitigations/mi-6_vulnerability-scanning-dast.md
@@ -4,6 +4,7 @@ title: Vulnerability Scanning - DAST
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: RELEASE
 nist-sp-800-53r5_references:
   - ra-5   # RA-5 Vulnerability Monitoring And Scanning
   - ca-8   # CA-8 Penetration Testing

--- a/docs/_mitigations/mi-7_vulnerability-scanning-dependencies.md
+++ b/docs/_mitigations/mi-7_vulnerability-scanning-dependencies.md
@@ -4,6 +4,7 @@ title: Vulnerability Scanning - Dependencies
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: BUILD
 nist-sp-800-53r5_references:
   - ra-5   # RA-5 Vulnerability Monitoring And Scanning
   - si-2   # SI-2 Flaw Remediation

--- a/docs/_mitigations/mi-8-version-control.md
+++ b/docs/_mitigations/mi-8-version-control.md
@@ -4,6 +4,7 @@ title: Version Control
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: CODE
 nist-sp-800-53r5_references:
   - id: sa-10
     note: Core control — requires source code and associated documentation to be placed under configuration management.

--- a/docs/_mitigations/mi-9-component-inventory.md
+++ b/docs/_mitigations/mi-9-component-inventory.md
@@ -4,6 +4,7 @@ title: Component Inventory
 layout: mitigation
 doc-status: Draft
 type: PREV
+phase: BUILD
 nist-sp-800-53r5_references:
   - cm-8   # CM-8 System Component Inventory
   - sr-4   # SR-4 Provenance


### PR DESCRIPTION
## Summary

Introduces an SDLC **phase taxonomy** describing where each mitigation primarily operates, and a corresponding **"Filter by Phase"** control in the catalogue.

- **Phases:** `CODE`, `BUILD`, `RELEASE`, `RUNTIME`, `LIFECYCLE` (the cross-cutting bucket for governance/process controls not tied to a single phase).
- **Config-driven:** like the existing risk/mitigation classifications, adding a phase needs only a `phase_classification` entry plus a matching `category_icons` icon — no template changes.

## Changes

- `docs/_config.yml` — add `phase_classification` map and phase entries in `category_icons`.
- `docs/_mitigations/*` — add a `phase` field to all 17 mitigations.
- `docs/_includes/catalogue.html`:
  - Add the "Filter by Phase" checkbox control; mitigation cards carry a `data-phase` attribute.
  - Phase narrows the mitigation panel directly and the risk panel via existing cross-linkage.
  - Rebalance the filter panel grid into two clean 12-col rows (Search/Type/Status/Reset, then Category/Phase) so the expanded panel no longer overflows and wraps awkwardly.

## Test plan

- Built locally via the `sdlc-jekyll` container; catalogue page serves 200.
- Verified the expanded filter panel lays out cleanly and phase checkboxes filter the mitigation list (and linked risks).