### PR TITLE
Split MI-4 into Requirements Repository (MI-4) and Requirements Approval for Release (MI-20)

### DIFF
--- a/docs/_mitigations/mi-20_requirements-approval.md
+++ b/docs/_mitigations/mi-20_requirements-approval.md
@@ -1,0 +1,52 @@
+---
+sequence: 20
+title: Requirements Approval for Release
+layout: mitigation
+doc-status: Draft
+type: PREV
+phase: RELEASE
+mitigates:
+  - ri-12  # Business Reputation Risk from Non-Approved Software Version Releases
+chain:
+  - requirements-governance
+related_mitigations:
+  - mi-4   # Requirements Repository
+  - mi-19  # Version Release Approval Gating
+---
+
+## Summary
+
+The requirements forming the scope of a release must be explicitly reviewed and agreed by accountable stakeholders representing the business needs of the specific release of the product before that release proceeds to production.
+
+## Description
+
+A release without an agreed requirements baseline is a release without a definition of what was to be done. This evidence outlines the scope and intent of the software change and without it being linked to the specific release we cannot demonstrate that what has been produced aligns with that intention. 
+
+This approval must come from authorised persons representing or delegated to by the business function owning the application to ensure that it is built matching their intention for the product. Otherwise this risks impacting overall quality, wasted effort and time (opportunity cost) and in cases of sensitive software material risk to controls and or operational risk.
+
+This control requires that, for every release, the requirements in scope are documented in the approved repository ([MI-4]({% link _mitigations/mi-4_requirements.md %})), reviewed by the stakeholders accountable for the business outcome and applicable obligations, and explicitly agreed before the release proceeds. It applies to the full requirement surface — business, functional, non-functional, security, and regulatory — not solely to feature-level user stories.
+
+## Requirements
+
+* Every release intended for production MUST have a documented set of requirements in scope, recorded in the approved requirements repository ([MI-4]({% link _mitigations/mi-4_requirements.md %}))
+* Each in-scope requirement MUST be documented to a level that permits meaningful review — at minimum, a clear statement of intent, an identified accountable owner, and any applicable non-functional, security, or regulatory considerations called out against the requirement itself
+* Requirements in scope for the release MUST be reviewed and agreed by named approvers representing, at minimum: the accountable business or product owner
+* Approvals MUST be attributed to a named individual, timestamped, and bound to the specific release identifier or the components that make that release.
+* The in-scope requirement identifiers MUST be bound to the release identifier such that the requirements for any given release, and the release for any given approved requirement, can be retrieved after the fact
+* Approval evidence MUST be recorded in an auditable system of record and retained for a period consistent with applicable regulatory requirements and the organisation's record-retention policy
+
+## Examples & Commentary
+
+* **Release-level review against a fixed scope:** Ahead of a release, the product owner generates a list from the requirements repository of every requirement in scope for the release. They walk the list, confirm that it matches what the business has committed to deliver, and record the approval against the release identifier in the governance platform.
+
+* **Reviewable requirement:** Each requirement in the release list carries a clear statement of intent, a named owner, and any applicable non-functional, security, or regulatory considerations recorded against it. A vague one-line ticket would not pass review; the approver needs enough on each item to know what they are agreeing to.
+
+* **Delegated approval:** The business function head for the application has delegated release approval to a named senior product manager. The delegation is recorded in the governance system, and approvals signed by the delegate are accepted as if signed by the function head.
+
+* **Traceability after the fact:** Months after a release, the business wants to evidence which release delivered a particular commitment. The product owner queries the requirements repository for the requirement, follows the link to the release in which it was approved, and produces the approval record without having to reconstruct the trail manually.
+
+## Links
+
+* [ISO 9001 — Quality management systems — Requirements](https://www.iso.org/standard/62085.html)
+* [ISO/IEC/IEEE 12207 — Systems and software engineering — Software life cycle processes](https://www.iso.org/standard/63712.html)
+* [COBIT 2019 — BAI02 Manage Requirements Definition](https://www.isaca.org/resources/cobit)

--- a/docs/_mitigations/mi-4_requirements.md
+++ b/docs/_mitigations/mi-4_requirements.md
@@ -1,73 +1,48 @@
 ---
 sequence: 4
-title: Requirements Management
+title: Requirements Repository
 layout: mitigation
-doc-status: Pre-Draft
+doc-status: Draft
 type: PREV
 phase: LIFECYCLE
 mitigates:
+  - ri-5   # Audit and Compliance Evidence Failure
+chain:
+  - requirements-governance
 related_mitigations:
+  - mi-8   # Version Control
+  - mi-20  # Requirements Approval for Release
 ---
 
-# Control 1: Requirement Repository Confirmation and Usage Attestation (XXXX-x§§1024)
-
 ## Summary
 
-Ensures requirements are maintained in an approved repository and that its correct usage is periodically attested.
-
-## Map to related risks
-
-•	Risk 1: Ungoverned or inconsistent requirements repositories
-•	Risk 2: Requirements progressing without minimum readiness
+Requirements Repository ensures that every application records its requirements in a designated and approved system of record. 
 
 ## Description
 
-This control establishes a single, governed source of truth for requirements and requires periodic confirmation that the repository is actively used and that requirements meet agreed readiness criteria.
+This control requires the organisation to designate an approved repository or repositories for storage of the requirements that are used as part of software development. It is important for such a repository to have appropriate requirements around storage in terms of duration since this will need to live alongside the software it helps inform and create, but also around appropriate audit trail of who created a requirement and what its content was at the time the work was carried out.
 
-## Requirements (Expectations)
+The repository must also either hold requirements immutably or maintain an audit trail sufficient to reconstruct the state of any requirement at any past point in time — a property commonly achieved by holding requirements as files in version control, or as tickets in a system that preserves full revision history.
 
-•	An approved requirements repository is designated for the application
-•	Usage of the repository is periodically attested
-•	Requirements meet an agreed Definition of Ready before development
+A repository can be designated on paper while teams continue to work from informal channels; periodic attestation by a named owner confirms it is in active use. The control sits at the entry point of the SDLC and is a precondition for traceability between requirements and tests ([MI-15]({% link _mitigations/mi-15_testing-requirements.md %})), release-time approval ([MI-20]({% link _mitigations/mi-20_requirements-approval.md %})), and audit reconstruction.
 
+## Requirements
 
-## Examples 
+* Each application MUST use an approved requirements repository
+* The approved repository MUST either hold requirements immutably or maintain a complete, attributable, timestamped audit trail of every creation, amendment, and closure sufficient to reconstruct the state of any requirement at any past point in time
+* The retention of requirement history (whether by immutability or by audit trail) MUST cover the period required by applicable regulation and the organisation's record-keeping policy
+* All requirements that enter development for the application MUST be recorded in an approved repository.
+* A named owner MUST attest, on a defined cadence (no less than annually, or following any material change to the application's delivery model), that the approved repository is in active use as the authoritative record of requirements for the application or organisation
+* Attestations MUST be timestamped, attributed to a named individual, and retained as governance evidence in accordance with the organisation's record-retention policy
 
-The control supports a “shift left” approach by embedding quality and clarity at the point requirements enter development, rather than relying on downstream inspection.
+## Examples & Commentary
 
-Links to external standards for controls
+* **Designated repository with enforcement:** An application's metadata in the technology system of record names a specific Jira project as its approved requirements repository. Branch-protection rules and PR templates require that every change reference a ticket in that project; PRs referencing tickets from other projects (or none) are blocked.
 
-•	ISO/IEC 27001 – information integrity and governance
-•	IREB / IIBA requirements management standards
+* **Audit trail via version control:** Requirements for a regulated trading application are held as Markdown files in a Git repository, with every change made through a pull request that records the author, the reviewer, the timestamp, and the rationale. The repository's commit history provides the complete reconstructable record; immutability is not required because the audit trail is sufficient.
 
+* **Audit trail via ticketing system:** An application uses a ticketing system that preserves every field change with author and timestamp. The state of any requirement on any past date can be reproduced from the ticket's revision history, satisfying the audit-trail requirement without external tooling.
 
-# Control 2: Requirements for Release – Reviewed and Agreed (XXXX-01068)
+## Links
 
-## Summary
-
-Ensures all business, functional, and non functional requirements for a release are formally reviewed and agreed.
-
-## Map to related risks
-
-•	Risk 2: Insufficiently defined requirements
-•	Risk 3: Lack of stakeholder agreement
-•	Risk 4: Missing non functional or regulatory requirements
-
-## Description
-
-This control establishes a formal approval baseline for requirements, confirming that what is being delivered has been explicitly reviewed and authorised prior to release.
-Requirements (Expectations)
-
-•	Requirements for the release are documented
-•	Business, functional, and non functional requirements are included
-•	Evidence of review and agreement is retained
-
-## Examples 
-
-RCTLDEF0001068 provides the authoritative confirmation that requirements are approved inputs into testing, release, and deployment decisions rather than informal guidance. 
-Links to external standards for controls
-
-Links to external standards for controls
-
-•	ISO 9001 – requirements review and approval
-•	COBIT – governance and assurance over requirements
+* [ISO/IEC/IEEE 29148 — Systems and software engineering — Life cycle processes — Requirements engineering](https://www.iso.org/standard/72089.html)


### PR DESCRIPTION
## Summary

The original `MI-4` Pre-Draft bundled two distinct controls under "Requirements Management". This PR splits them into two fleshed-out, separately-scoped mitigations and links them via the framework's existing `chain:` mechanism.

- **MI-4 Requirements Repository** (`LIFECYCLE`, mitigates `ri-5`) — each application uses an approved requirements repository that either holds requirements immutably or maintains an audit trail sufficient to reconstruct the state of any requirement at any past point in time, attested periodically as in active use.
- **MI-20 Requirements Approval for Release** (`RELEASE`, mitigates `ri-12`) — the requirements forming the scope of a release are explicitly reviewed and agreed by the accountable business/product owner (or delegate) before the release proceeds to production, with in-scope requirement identifiers bound bidirectionally to the release identifier.

Both controls share a `requirements-governance` chain, so each page renders the other as a left-to-right stepper in its Related Mitigations card (one logically depends on the other: MI-20 approves what MI-4's repository holds).

## Notes

- `scripts/readiness-check` passes for both files (only the pre-existing "no regulatory references" soft warning, consistent with sibling Draft controls such as MI-19).
- No risk-file edits needed — back-links resolve automatically via the risk layout's reverse lookup on `mitigates:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)