### PR TITLE
MI-8: tamper-evident history, controlled amendment exceptions, and release traceability

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,6 +45,8 @@ document_status:
     description: "Initial brainstorming or collection of ideas, notes, and outlines. The document is not yet formally written."
   - name: Draft
     description: "The document is in the early stages of development, with content being written and structured but not yet polished."
+  - name: First-Reading-Approved
+    description: "The document has passed its first reading by the working group and is substantially complete, but has not yet received final approval."
   - name: Working-Group-Approved
     description: "The document is in its final form and has been approved by the working group."
 

--- a/docs/_includes/catalogue.html
+++ b/docs/_includes/catalogue.html
@@ -158,6 +158,7 @@
                                                     {% if risk_status != '' %}
                                                       {% if risk_status == 'Published' %}{% assign status_badge = 'bg-success' %}
                                                       {% elsif risk_status == 'Working-Group-Approved' %}{% assign status_badge = 'bg-info text-dark' %}
+                                                      {% elsif risk_status == 'First-Reading-Approved' %}{% assign status_badge = 'bg-primary' %}
                                                       {% elsif risk_status == 'Draft' %}{% assign status_badge = 'bg-warning text-dark' %}
                                                       {% else %}{% assign status_badge = 'bg-secondary' %}{% endif %}
                                                       <span class="badge {{ status_badge }}" style="font-size:0.65em;">{{ risk_status }}</span>
@@ -240,6 +241,7 @@
                                                     {% if mitigation_status != '' %}
                                                       {% if mitigation_status == 'Published' %}{% assign status_badge = 'bg-success' %}
                                                       {% elsif mitigation_status == 'Working-Group-Approved' %}{% assign status_badge = 'bg-info text-dark' %}
+                                                      {% elsif mitigation_status == 'First-Reading-Approved' %}{% assign status_badge = 'bg-primary' %}
                                                       {% elsif mitigation_status == 'Draft' %}{% assign status_badge = 'bg-warning text-dark' %}
                                                       {% else %}{% assign status_badge = 'bg-secondary' %}{% endif %}
                                                       <span class="badge {{ status_badge }}" style="font-size:0.65em;">{{ mitigation_status }}</span>

--- a/docs/_mitigations/mi-8-version-control.md
+++ b/docs/_mitigations/mi-8-version-control.md
@@ -32,7 +32,7 @@ mitigates:
 ---
 
 ## Summary
-Software and configuration must be stored winth an approved version control system.
+Software and configuration must be stored within an approved version control system.
 
 ## Description
 Version control is required to maintain a history of all software and configuration changes across all releases. It provides traceability of who made changes and when, establishing the provenance of software over time.
@@ -41,10 +41,14 @@ The control establishes verifiable evidence of the state of source code or confi
 
 Version control is also integral to ensuring that the software being built and tested is the same software being deployed, by tracking the specific commit or version and providing a reference for traceability.
 
+The integrity of this history is what gives it evidentiary value. The objective is that history cannot be altered or destroyed without detection — not that it can never change. Strict immutability is the simplest way to achieve this, but it is equally acceptable to permit amendment where the system retains a retrievable, attributable record of what changed and why. Unauthorised modification or deletion remains prohibited; only authorised, logged amendment — such as purging a committed secret — is permitted.
+
 ## Requirements
 In order for a version control system to be effective, it must provide the following properties when used for storing software and configuration.
 
-* **Immutable History** — The version control system must preserve the integrity of history to prevent tampering and maintain the audit trail.
+* **Tamper-Evident History** — The version control system must either preserve history immutably, or provide a retrievable, attributable record of the events and changes that took place, such that the state of the software and configuration at any past point in time can be reconstructed. In either case, history must not be silently or undetectably altered or destroyed.
+* **Controlled History Amendment** — Where history is amended for legitimate reasons — for example, to remove committed secrets or personal data that must not persist — the amendment must be an authorised, logged exception. The fact of the amendment, its justification, and the authorising party must be recorded, and the amendment must not be used to obscure the legitimate change record.
+* **Release Traceability** — It must be possible to retrieve the exact version (commit or revision) of software and configuration that was released to production, for the applicable retention period.
 * **Verified Committers** — The version control system must record the author of each change. Techniques such as commit signing could be employed to demonstrate this.
 * **Retention** — History must be maintained for the lifetime of the software or in alignment with applicable retention requirements.
 * **Access Control** — The version control system must support access control and should be configured appropriately.
@@ -53,13 +57,13 @@ In order for a version control system to be effective, it must provide the follo
 
 **Git** is the most widely adopted distributed version control system and is the de facto standard for software development in regulated and non-regulated environments alike.
 
-* **Immutable History** — Every commit is identified by a cryptographic SHA hash derived from its content and its parent commits, making silent tampering detectable.
+* **Tamper-Evident History** — Every commit is identified by a cryptographic SHA hash derived from its content and its parent commits, making silent tampering detectable. Branch protection rules on the default and release branches block force-pushes and history rewrites, so published history cannot be altered; where a secret must be purged, the rewrite is performed as an authorised, logged exception rather than an everyday operation.
 * **Verified Committers** — Git supports GPG and SSH commit signing natively. Hosting platforms such as GitHub and GitLab can be configured to require signed commits on protected branches.
 * **Access Control** — Enforced at the hosting platform level via branch protection rules, required reviewers, and role-based repository permissions.
 
 **Subversion (SVN)** is a centralised version control system still found in some legacy financial services environments.
 
-* **Immutable History** — SVN maintains a sequential, server-side revision history. Once committed, revisions cannot be altered without administrator access to the repository backend.
+* **Tamper-Evident History** — SVN maintains a sequential, server-side revision history. Once committed, revisions cannot be altered without administrator access to the repository backend, and such backend actions are logged and attributable.
 * **Verified Committers** — SVN records the authenticated username against each commit. Commit signing is not natively supported; identity relies on server authentication (e.g. LDAP, Kerberos).
 * **Access Control** — Controlled server-side via path-based authorisation, allowing fine-grained read/write permissions per directory or branch.
 

--- a/docs/_mitigations/mi-8-version-control.md
+++ b/docs/_mitigations/mi-8-version-control.md
@@ -2,7 +2,7 @@
 sequence: 8
 title: Version Control
 layout: mitigation
-doc-status: Draft
+doc-status: First-Reading-Approved
 type: PREV
 phase: CODE
 nist-sp-800-53r5_references:


### PR DESCRIPTION
Closes #83.

## Summary

Addresses the points raised in #83 against **MI-8 Version Control**, and introduces a new document status.

### MI-8 content (issue #83)

- **Tamper-Evident History** (was "Immutable History") — history must *either* be preserved immutably *or* provide a retrievable, attributable record of the events and changes that took place, sufficient to reconstruct prior state. The objective is that history cannot be altered or destroyed undetectably — not that it can never change.
- **Controlled History Amendment** (new) — permits the exception the issue asked for: authorised, logged rewrites for legitimate reasons such as purging committed secrets or personal data, with the amendment, its justification, and the authorising party recorded.
- **Release Traceability** (new) — the exact version released to production must be retrievable for the applicable retention period.
- **Description** — adds a paragraph making explicit that *unauthorised* modification or deletion remains prohibited, keeping the control consistent with its AU-9 mapping while allowing the controlled exception.
- **Examples** — the Git example now calls out branch protection blocking force-pushes and history rewrites. Aligns "released to production" wording with MI-15/MI-16/MI-20 and fixes a `winth` typo.

### New document status

- Adds **`First-Reading-Approved`** to `document_status` in `_config.yml` — an intermediate state between `Draft` and `Working-Group-Approved` for documents that have passed their first reading by the working group but are not yet finally approved.
- Adds a badge colour (`bg-primary`) for it in the catalogue rendering (risk and mitigation cards).
- Sets **MI-8** to `First-Reading-Approved`, having passed its first reading.

## Validation

`scripts/readiness-check` passes for `mi-8-version-control.md` (no open items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)