### PR TITLE
Add Definitions of Terms glossary subpage (draft)

### DIFF
--- a/docs/_data/glossary.yml
+++ b/docs/_data/glossary.yml
@@ -1,0 +1,112 @@
+# Definitions of terms used across the SDLC Controls Framework.
+# DRAFT — to be revisited. Rendered alphabetically by `definitions.md`.
+# Each entry: term, slug (anchor id), definition.
+
+- term: Attestation
+  slug: attestation
+  definition: >-
+    A named, timestamped confirmation by an accountable owner that a stated
+    condition holds — for example, that a repository is in active use. An
+    attestation is itself an evidentiary record and is retained as governance
+    evidence.
+
+- term: Audit trail
+  slug: audit-trail
+  definition: >-
+    An attributable, timestamped record of changes — who did what, and when —
+    sufficient to reconstruct the state of something at any past point in time.
+    Where strict immutability is not used, a sufficient audit trail is the
+    accepted alternative for preserving history.
+
+- term: Content-addressable identity
+  slug: content-addressable-identity
+  definition: >-
+    Identifying an artifact by a cryptographic hash of its contents, so that any
+    change to the artifact produces a different identity and tampering is
+    immediately detectable.
+
+- term: Control chain
+  slug: control-chain
+  definition: >-
+    A set of controls that are logically dependent on one another and linked as
+    an ordered sequence, where one control establishes the conditions the next
+    relies on (for example, a requirements repository feeding release-time
+    requirements approval).
+
+- term: Control phase
+  slug: control-phase
+  definition: >-
+    The point in the software lifecycle at which a control principally applies —
+    for example CODE, RELEASE, RUNTIME, or LIFECYCLE (spanning the whole cycle).
+
+- term: Control type
+  slug: control-type
+  definition: >-
+    The control's mode of action, such as PREV (preventive — stops an undesirable
+    outcome occurring). Used to classify how a control mitigates its risks.
+
+- term: Deployment gating
+  slug: deployment-gating
+  definition: >-
+    A policy-based check at the point of deployment that blocks an individual
+    deployment from proceeding unless defined technical criteria are met.
+    Distinct from version release approval, which authorises a version to be
+    released at all.
+
+- term: Document status
+  slug: document-status
+  definition: >-
+    The maturity of a control or risk document: Pre-Draft (initial notes), Draft
+    (being written), First-Reading-Approved (passed first working-group reading,
+    substantially complete but not yet final), and Working-Group-Approved (final,
+    approved).
+
+- term: Immutability
+  slug: immutability
+  definition: >-
+    The property that, once recorded, something cannot be changed. In this
+    framework, history may be preserved either by strict immutability or by a
+    sufficient audit trail; the required property is that history cannot be
+    altered or destroyed undetectably.
+
+- term: Mitigation (Control)
+  slug: mitigation-control
+  definition: >-
+    A control that reduces one or more risks. "Mitigation" and "control" are used
+    interchangeably; each mitigation references the risks it addresses.
+
+- term: Provenance
+  slug: provenance
+  definition: >-
+    A documented, verifiable chain of custody for a software artifact, from
+    source commit through build and into deployment, establishing where it came
+    from and how it was produced.
+
+- term: Regulatory guidance vs. industry standard
+  slug: regulatory-guidance-vs-industry-standard
+  definition: >-
+    A reference distinction used in this framework. Regulatory guidance is issued
+    by regulators (for example the FFIEC IT Handbook); industry standards are
+    voluntary, consensus-based frameworks (for example NIST, ISO/IEC, SLSA).
+
+- term: Release, deployment, and promotion
+  slug: release-deployment-promotion
+  definition: >-
+    A release is a version of software made available for production; deployment
+    is the act of placing software into an environment; promotion is moving a
+    build forward through environments toward production. The framework uses
+    "released to production" for the point software goes live.
+
+- term: Risk
+  slug: risk
+  definition: >-
+    An undesirable outcome the framework seeks to reduce. Each risk is addressed
+    by one or more mitigations (controls).
+
+- term: Tamper-evident history
+  slug: tamper-evident-history
+  definition: >-
+    History that cannot be altered or destroyed without detection. It does not
+    require that history never change — only that any change is detectable and
+    that no data is silently lost. Authorised, logged amendments (for example,
+    purging a committed secret) are permitted.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -28,6 +28,7 @@
 
     <footer class="py-4 bg-light border-top mt-5">
         <div class="container text-center">
+            <p class="mb-1"><a href="{{ site.baseurl }}/definitions.html">Definitions of Terms</a></p>
             <p class="mb-0">Distributed under the <a href="https://creativecommons.org/licenses/by/4.0/deed.en">CC-BY-4.0</a> licence.</p>
         </div>
     </footer>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,0 +1,39 @@
+---
+layout: default
+---
+
+<header class="py-5 bg-light border-bottom">
+    <div class="container">
+        <div class="mb-4">
+            <a href="{{ site.baseurl }}/" class="text-decoration-none">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
+                </svg>
+                Back to Catalogue
+            </a>
+        </div>
+        <div class="d-flex align-items-center">
+            <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Controls Framework Icon" style="height: 72px;" class="me-3 mb-0">
+            <div>
+                <h1 class="display-4 mb-0">{{ page.title }}</h1>
+                {% if page.subtitle %}<p class="lead mb-0">{{ page.subtitle }}</p>{% endif %}
+            </div>
+        </div>
+    </div>
+</header>
+
+<main class="container py-5">
+    <div class="row">
+        <div class="col-lg-9">
+            {% if page.draft %}
+            <div class="alert alert-warning d-flex align-items-center" role="alert">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" viewBox="0 0 16 16">
+                    <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+                </svg>
+                <div><strong>Draft.</strong> This page is a work in progress and will be revisited.</div>
+            </div>
+            {% endif %}
+            {{ content }}
+        </div>
+    </div>
+</main>

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: "Definitions of Terms"
+subtitle: "What we mean by some of the framework's more nuanced terms"
+draft: true
+---
+
+<p class="text-muted">
+This glossary explains terms used across the risk and mitigation catalogue that
+carry a specific meaning in this framework, or that are easy to misread. It is a
+living document.
+</p>
+
+{% assign terms = site.data.glossary | sort: "term" %}
+
+<nav class="mb-4" aria-label="Glossary index">
+  <div class="d-flex flex-wrap gap-2">
+    {% for entry in terms %}
+    <a href="#{{ entry.slug }}" class="badge rounded-pill bg-light text-dark border text-decoration-none">{{ entry.term }}</a>
+    {% endfor %}
+  </div>
+</nav>
+
+<dl class="glossary">
+  {% for entry in terms %}
+  <dt id="{{ entry.slug }}" class="h5 mt-4">{{ entry.term }}</dt>
+  <dd class="mb-3">{{ entry.definition }}</dd>
+  {% endfor %}
+</dl>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,6 @@ To meet these expectations, SDLC processes must incorporate robust controls that
 
 This project aims to present a curated set of common risks encountered during the SDLC, along with their corresponding mitigations. By establishing a standardized library of controls, the goal is to streamline compliance efforts, reduce uncertainty, and promote safe, repeatable development practices aligned with regulatory expectations.
 
+New to the terminology? See the [Definitions of Terms]({{ site.baseurl }}/definitions.html) for what we mean by the framework's more nuanced language.
+
 {% include catalogue.html %}


### PR DESCRIPTION
## Summary

Adds a **Definitions of Terms** subpage explaining framework-specific or easily-misread terms used across the risk and mitigation catalogue.

The page is **marked as draft** — the term list and wording are a deliberate first cut to be revisited; a banner says so at the top.

### What's included
- **`docs/_data/glossary.yml`** — data-driven term/definition list (15 starter terms), consistent with the framework's data-driven style and allowing controls to deep-link to a term later (e.g. `…/definitions.html#tamper-evident-history`).
- **`docs/definitions.md`** — renders the glossary alphabetically with a clickable pill index and per-term anchors.
- **`docs/_layouts/page.html`** — a reusable subpage layout (logo, title, "Back to Catalogue") with a conditional draft banner driven by `draft: true` in front matter. Available for future subpages.
- **Discoverability** — a site-wide footer link (in `default.html`) plus a link from the index introduction.

### Starter terms
Attestation · Audit trail · Content-addressable identity · Control chain · Control phase · Control type · Deployment gating · Document status · Immutability · Mitigation (Control) · Provenance · Regulatory guidance vs. industry standard · Release/deployment/promotion · Risk · Tamper-evident history

## Validation
`scripts/readiness-check` unchanged at 24/31 (the glossary doesn't touch risk/mitigation documents). Built and reviewed locally via Jekyll; the draft banner, pill index, anchors, and footer link render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)