### PR TITLE
Add EU/UK/US regulatory mappings: pilot on MI-01 Code Review

### DIFF
--- a/docs/_data/eu-dora.yml
+++ b/docs/_data/eu-dora.yml
@@ -1,0 +1,26 @@
+# EU — DORA (Regulation (EU) 2022/2554) and the RTS on ICT risk
+# management framework (Commission Delegated Regulation (EU) 2024/1774).
+# DORA applies to EU financial entities from 17 January 2025 and supersedes
+# the EBA Guidelines on ICT and security risk management (EBA/GL/2019/04),
+# which were narrowed to payment-service-user relationship management by
+# EBA/GL/2025/02 (applicable 20 May 2025). Map to DORA, not the EBA guidelines.
+# Authoritative text: https://eur-lex.europa.eu/eli/reg_del/2024/1774/oj
+
+dora-art-9-4-e:
+  title: 'DORA Art. 9(4)(e) — ICT change management policies'
+  url: https://www.springlex.eu/en/packages/dora/dora-regulation/article-9/
+rts-art-15:
+  title: 'RTS 2024/1774 Art. 15 — ICT project management'
+  url: https://www.springlex.eu/en/packages/dora/rts-rmf-regulation/article-15/
+rts-art-16-2:
+  title: 'RTS 2024/1774 Art. 16(2) — Testing and approval of ICT systems'
+  url: https://www.springlex.eu/en/packages/dora/rts-rmf-regulation/article-16/
+rts-art-16-3:
+  title: 'RTS 2024/1774 Art. 16(3) — Source code reviews (static and dynamic)'
+  url: https://www.springlex.eu/en/packages/dora/rts-rmf-regulation/article-16/
+rts-art-16-7:
+  title: 'RTS 2024/1774 Art. 16(7) — Source code integrity controls'
+  url: https://www.springlex.eu/en/packages/dora/rts-rmf-regulation/article-16/
+rts-art-17-1:
+  title: 'RTS 2024/1774 Art. 17(1) — ICT change management procedures'
+  url: https://www.springlex.eu/en/packages/dora/rts-rmf-regulation/article-17/

--- a/docs/_data/uk-fca.yml
+++ b/docs/_data/uk-fca.yml
@@ -1,0 +1,14 @@
+# UK — FCA / PRA operational resilience regime. Deliberately outcome-based:
+# there is no UK rule that says "perform code reviews". Mitigations map as
+# evidence supporting resilience outcomes, so the per-reference notes carry
+# the explanation rather than clause numbers.
+
+sysc-15a-2:
+  title: 'FCA SYSC 15A.2 — Operational resilience requirements'
+  url: https://handbook.fca.org.uk/handbook/SYSC/15A/2.html
+pra-ss1-21:
+  title: 'PRA SS1/21 — Operational resilience: impact tolerances'
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2021/march/operational-resilience-impact-tolerances-for-important-business-services-ss
+fca-tech-change:
+  title: 'FCA Multi-firm review — Implementing Technology Change (2021)'
+  url: https://www.fca.org.uk/publications/multi-firm-reviews/implementing-technology-change

--- a/docs/_data/us-nydfs.yml
+++ b/docs/_data/us-nydfs.yml
@@ -1,0 +1,7 @@
+# US — NYDFS 23 NYCRR Part 500. Applies to banks, insurers and fintechs
+# licensed in New York, including many non-US-headquartered firms.
+# Complements the FFIEC IT Handbook dataset (ffiec-itbooklets.yml).
+
+nydfs-500-08:
+  title: 'NYDFS 23 NYCRR §500.08 — Application Security'
+  url: https://www.dfs.ny.gov/system/files/documents/2023/03/23NYCRR500_0.pdf

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -119,9 +119,27 @@ layout: default
 
             {% comment %} Regulatory guidance — issued or enforced by regulators {% endcomment %}
             {% include reference-card.html
+                references=page.eu-dora_references
+                dataset="eu-dora"
+                heading="EU — DORA / RTS 2024/1774"
+                type="Regulatory Guidance" %}
+
+            {% include reference-card.html
+                references=page.uk-fca_references
+                dataset="uk-fca"
+                heading="UK — FCA / PRA Operational Resilience"
+                type="Regulatory Guidance" %}
+
+            {% include reference-card.html
                 references=page.ffiec-itbooklets_references
                 dataset="ffiec-itbooklets"
-                heading="FFIEC IT Handbook"
+                heading="US — FFIEC IT Handbook"
+                type="Regulatory Guidance" %}
+
+            {% include reference-card.html
+                references=page.us-nydfs_references
+                dataset="us-nydfs"
+                heading="US — NYDFS Part 500"
                 type="Regulatory Guidance" %}
 
             {% include reference-card.html
@@ -170,6 +188,3 @@ layout: default
         </div>
     </div>
 </main>
-
-
-

--- a/docs/_mitigations/mi-1_code-review.md
+++ b/docs/_mitigations/mi-1_code-review.md
@@ -1,5 +1,5 @@
 ---
-sequence: 22
+sequence: 1
 title: Code Review
 layout: mitigation
 doc-status: Draft

--- a/docs/_mitigations/mi-22_code-review.md
+++ b/docs/_mitigations/mi-22_code-review.md
@@ -11,6 +11,81 @@ nist-sp-800-53r5_references:
   - sa-10  # SA-10 Developer Configuration Management
   - sa-11  # SA-11 Developer Testing And Evaluation
   - au-12  # AU-12 Audit Record Generation
+eu-dora_references:
+  - id: rts-art-16-3
+    note: >
+      Mandates source code reviews covering both static and dynamic testing,
+      with vulnerabilities identified, tracked through an action plan, and
+      monitored to closure. The review gate plus SAST integration required by
+      this mitigation implements the review; the immutable review records
+      provide the evidence.
+  - id: rts-art-17-1
+    note: >
+      Art. 17(1)(b) requires independence between the functions approving a
+      change and those requesting or implementing it — the regulatory basis
+      for "the author MUST NOT satisfy the human-review requirement for their
+      own change". Art. 17(1)(a) and (c) require each change to be verified
+      against ICT security requirements, tested, quality-assured and
+      documented; the review record bound to the change-set identity
+      demonstrates this per change.
+  - id: rts-art-16-7
+    note: >
+      Requires controls protecting the integrity of source code, whether
+      developed in-house or supplied by third parties. Technically blocking
+      admission to the protected baseline without a valid review outcome is
+      the primary integrity control over the baseline.
+  - id: dora-art-9-4-e
+    note: >
+      The parent DORA obligation: documented ICT change management policies
+      following a risk-based approach. The deterministic, machine-evaluable
+      review policy this mitigation requires is a direct implementation.
+uk-fca_references:
+  - id: sysc-15a-2
+    note: >
+      Outcome-based rather than prescriptive: firms must be able to remain
+      within impact tolerances for important business services. Mandatory
+      review of changes reduces the likelihood that defective or unauthorised
+      changes disrupt those services, and retained review records evidence
+      this capability in the firm's operational resilience self-assessment.
+  - id: pra-ss1-21
+    note: >
+      The PRA's parallel expectations for dual-regulated firms. Same mapping
+      logic as SYSC 15A: this mitigation is evidence of the technology-change
+      leg of the firm's resilience capability.
+  - id: fca-tech-change
+    note: >
+      The FCA's closest statement of SDLC-level expectations. It found failed
+      technology changes cause roughly a quarter of high-severity incidents,
+      and that strong governance, robust pre-deployment assurance and
+      frequent, smaller releases correlate with higher change success rates —
+      directly supporting risk-based review modes and fast review turnaround
+      over batched changes.
+ffiec-itbooklets_references:
+  - id: dam-2
+    note: >
+      Section II.B.2 gives code review as the canonical dual-control example:
+      "during development, code review involves a second individual to review
+      code before it is released to test environments. Segregation of duties
+      and dual control help foster security and resilience."
+  - id: dam-3
+    note: >
+      Sections III.A and III.D identify code review as a primary risk
+      identification and mitigation control — detecting errors before code
+      migrates toward production.
+  - id: dam-4
+    note: >
+      Section IV.D (Secure Development) covers manual and automated code
+      review, source code security analyzers, and expects management to
+      validate that the code review process meets its needs — the basis for
+      maintaining approved automated review tools and configurations.
+us-nydfs_references:
+  - id: nydfs-500-08
+    note: >
+      Requires written procedures ensuring secure development practices for
+      in-house developed applications, periodically reviewed by the CISO.
+      A documented, technically enforced review policy with retained records
+      is a central component of those procedures, and supports the covered
+      entity's annual certification.
 mitigates:
   - ri-8   # Unauthorised Change
   - ri-4   # Vulnerable Software in Production


### PR DESCRIPTION
# Jurisdiction-based regulatory mappings: pilot on MI-01 Code Review

At the FINOS SDLC workshop in London I took an action to investigate how the framework's mitigations could map to the regulations member firms are actually examined against. This PR is what I've come back with.

The framework's existing references (NIST, ISO, SLSA) answer *"is this good practice?"*. These new sections answer a different question: *"which regulatory obligation does this discharge?"*, grouped by jurisdiction (EU, UK, US). That's the question firms face in DORA framework reviews, FCA/PRA operational resilience self-assessments, FFIEC examinations and NYDFS annual certifications.

## Why these regulations

The selection was deliberate. Three criteria: binding obligations rather than voluntary guidance, text that actually reaches SDLC-level activity, and coverage of the jurisdictions where most member firms are supervised.

- **EU: DORA (Reg 2022/2554) + RTS on ICT risk management (CDR 2024/1774).** DORA is directly applicable to nearly all EU financial entities since January 2025, and the RTS is where the obligations become concrete enough to map: Art. 16(3) literally mandates "source code reviews covering both static and dynamic testing". We deliberately did not map to EBA/GL/2019/04: DORA superseded it for this purpose, and EBA/GL/2025/02 has since narrowed it to payment-service-user relationship management. Mapping to the guidelines would point firms at the wrong instrument.
- **UK: FCA SYSC 15A / PRA SS1/21 + the FCA's *Implementing Technology Change* review.** The UK regime is outcome-based; there's no rule that says "perform code reviews". SYSC 15A and SS1/21 are what firms are assessed against, and the multi-firm review is the closest the FCA has come to stating SDLC-level expectations (it found failed technology changes cause roughly a quarter of high-severity incidents). Because the regime is outcome-based, these entries carry the explanation in per-reference notes rather than clause citations.
- **US: FFIEC IT Handbook + NYDFS Part 500.** No single US regulator owns this space, so two anchors: the FFIEC handbook is the examiners' baseline for banking and was already a dataset in the framework, while NYDFS 23 NYCRR Part 500 is the most prescriptive state-level cyber regulation, with an explicit application security requirement (§500.08), and it reaches many non-US-headquartered firms through New York licensing.

Piloted on **MI-01 Code Review** because it has the strongest hooks in all three jurisdictions.

## What's in the PR

- **`_data/eu-dora.yml`**: DORA (2022/2554) + the RTS on ICT risk management framework (CDR 2024/1774).
- **`_data/uk-fca.yml`**: FCA SYSC 15A, PRA SS1/21, and the FCA's *Implementing Technology Change* multi-firm review, each with an explanatory note.
- **`_data/us-nydfs.yml`**: NYDFS 23 NYCRR §500.08 (Application Security), complementing the existing FFIEC dataset.
- **`_layouts/mitigation.html`**: three new `reference-card.html` includes under Regulatory Guidance, and the existing FFIEC heading renamed to "US — FFIEC IT Handbook" for consistency.
- **`_mitigations/mi-1_code-review.md`**: frontmatter references with notes for all four cards (EU DORA, UK FCA/PRA, US FFIEC using the existing `dam-*` dataset entries, US NYDFS). Body unchanged. Renumbered from MI-22 to MI-01: that slot was unassigned, and code review is a foundational control rather than a late addition.

No new UI: `reference-card.html` already renders `{id, note}` references as expandable `<details>` dropdowns. This PR is the first use of that mechanism for regulatory explanations.

## Highlights of the MI-01 mapping

- **RTS 2024/1774 Art. 16(3)**: mandates source code reviews (static + dynamic) with a monitored remediation action plan.
- **RTS 2024/1774 Art. 17(1)(b)**: requires independence between change approvers and implementers, the regulatory basis for "the author MUST NOT satisfy the human-review requirement for their own change".
- **FFIEC DAM booklet (Aug 2024) II.B.2**: names code review by a second individual as the canonical dual-control example.
- **FCA *Implementing Technology Change***: endorses strong governance and frequent, smaller releases, aligning with this mitigation's risk-based review modes.

## If the approach lands

The same datasets serve MI-8 Version Control, MI-12 Deployment Gating, MI-19 Version Approval (RTS Art. 17 nearly verbatim), MI-5/6/7 vulnerability scanning (RTS Art. 10 + 16(3)), and MI-14 Test Evidence (RTS Art. 16(2)).

Opening as draft for discussion: naming of the cards/datasets, note wording, and whether NYDFS belongs as a separate card are all up for debate.
