### PR TITLE
Add project SCOPE definition

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,3 @@
+# Scope
+
+The SDLC Common Controls Catalog is scoped to **software delivery in regulated industries** focusing on financial services. The aim is to cover all phases of the software delivery lifecycle and the supervision that take place upon those artefacts in order to ensure that appropriate risks are mitigated and evidence provided to demonstrate the oversight has taken place.  The phases include from requirements through development, build, test, and release, up to and including runtime checks on the delivered artifacts.


### PR DESCRIPTION
Adds `SCOPE.md` defining the working group's scope, as required by the FINOS standards project structure and already referenced (but missing) from `GOVERNANCE.md` §4.4.

Scope wording is taken from the draft FINOS standard proposal: software delivery in regulated industries, focusing on financial services, covering all phases of the delivery lifecycle from requirements up to and including runtime checks on the delivered artifacts.