### PR TITLE
Adapt GOVERNANCE.md to this project (was unedited AIGF copy)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
-# AI Governance Framework Governance Policy
+# SDLC Controls Framework Governance Policy
 
-This document provides the governance policy for the development of the AI Governance Framework (AIGF) specification and related materials in the AIGF Standard (the “Working Group”).
+This document provides the governance policy for the development of the SDLC Controls Framework specification and related materials (the “Working Group”).
 
 ## 1.	Roles.
 
@@ -8,34 +8,28 @@ The Working Group includes the following roles:
 
 ### 1.1. Participants
 
-“Participants” are those that have made Contributions to the Working Group subject to the [Community Specification Contribution Policy 1.0](https://spdx.org/licenses/Community-Spec-1.0.html).  The AIGF Standard Working Group has the specific purpose of defining and releasing subsequent updates to the Standard. In practice, that means people that attend and contribute to meetings, raise issues, pull requests (to submit patches to the Standard) and reviews.
+“Participants” are those that have made Contributions to the Working Group subject to the [Community Specification Contribution Policy 1.0](https://spdx.org/licenses/Community-Spec-1.0.html).  The SDLC Controls Framework Working Group has the specific purpose of defining and releasing subsequent updates to the framework. In practice, that means people that attend and contribute to meetings, raise issues, pull requests (to submit patches to the framework) and reviews.
 
 #### How do you become a Participant?
 
-Becoming an AIGF Participant is as easy as attending a meeting and/or raising issues for changes you'd like see in the Standard, commenting on issues others have raised or even asking questions (which can often result in the clarification of the Standard's documentation to help others with the same questions in future).
+Becoming a Participant is as easy as attending a meeting and/or raising issues for changes you'd like to see in the framework, commenting on issues others have raised or even asking questions (which can often result in the clarification of the framework's documentation to help others with the same questions in future).
 
 #### Register to vote
-Participants may register to vote on changes to the AIGF Standard (see [Section 2](#2decision-making) below). To do so register to the group by sending an empty email to [ai-governance-framework+subscribe@lists.finos.org] to join the enrolled voting participants group.
-
-Upon enrollment as an [AIGF voting participant](https://github.com/orgs/finos/teams/ai-governance-framework-participants), you will be invited to join the [FINOS GitHub organization](https://github.com/orgs/finos/people) and the [aigf-participants](https://github.com/orgs/finos/teams/ai-governance-framework-participants) GitHub team.
-
-- [View the AIGF Participants GitHub Team](https://github.com/orgs/finos/teams/ai-governance-framework-participants)
+Participants may register to vote on changes to the SDLC Controls Framework (see [Section 2](#2decision-making) below). To do so, register to the group by sending an empty email to [sdlc-framework+subscribe@lists.finos.org](mailto:sdlc-framework+subscribe@lists.finos.org) to join the enrolled voting participants group.
 
 ### 1.2. Discussion Groups
 
-The Working Group may form one or more "Discussion Groups" to organize collaboration around a particular aspect of a specification. Discussion Groups are for discussion only.  Approval of all portions of a specification is subject to the consensus-based decision-making process of the AIGF Standard Working Group.
+The Working Group may form one or more "Discussion Groups" to organize collaboration around a particular aspect of a specification. Discussion Groups are for discussion only.  Approval of all portions of a specification is subject to the consensus-based decision-making process of the SDLC Controls Framework Working Group.
 
 ### 1.3. Maintainers 
 
-“Maintainers” are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  The Working Group has designates six Maintainer(s). The Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.  
-
-- [View the AIGF Maintainers GitHub Team](https://github.com/orgs/finos/teams/ai-governance-framework-maintainers)
+“Maintainers” are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  The Working Group designates its Maintainers, listed in [MAINTAINERS.md](MAINTAINERS.md). The Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.  
 
 #### How do you become a Maintainer?
 
-Once you are an enrolled participant in AIGF, you can apply to become an **maintainer** by contacting the existing AIGF maintainers at [ai-gov-framework-maintainers@lists.finos.org](mailto:ai-gov-framework-maintainers@lists.finos.org) and then seeking the approval of the AIGF Standards Working Group. Generally, the maintainers will look for both a history of contribution to AIGF and a commitment to investing sufficient time in the role from any prospective candidates before proposing them to the Standards Working Group for approval. 
+Once you are an enrolled participant, you can apply to become a **maintainer** by contacting the existing maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) and then seeking the approval of the Working Group. Generally, the maintainers will look for both a history of contribution to the framework and a commitment to investing sufficient time in the role from any prospective candidates before proposing them to the Working Group for approval. 
 
-If you are new to AIGF, but willing to make the investment of time, the maintainers can work with you to build up a history of contribution.
+If you are new to the project, but willing to make the investment of time, the maintainers can work with you to build up a history of contribution.
 
 ## 2.	Decision Making.
 
@@ -67,7 +61,7 @@ Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi
 
 **4.2.	Draft.**  Each Pre-Draft document of the Working Group must first be Approved to become a “Draft Specification”. Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification. At this stage, the document is in the early stages of development, with content being written and structured but not yet polished.
 
-**4.4.	Working Group Approval.**  Once the Working Group believes it has achieved the objectives for its specification as described in the [Scope](./SCOPE), it will Approve that Draft Specification and progress it to “Approved Specification” status. The document is in its final form.
+**4.4.	Working Group Approval.**  Once the Working Group believes it has achieved the objectives for its specification as described in the [Scope](./SCOPE.md), it will Approve that Draft Specification and progress it to “Approved Specification” status. The document is in its final form.
 
 **4.5.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer(s) will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
 


### PR DESCRIPTION
GOVERNANCE.md was copied from the AI Governance Framework and never adapted — it was titled "AI Governance Framework Governance Policy", referenced AIGF throughout, and pointed enrollment and maintainer contact at AIGF mailing lists and GitHub teams. Anyone following it would have enrolled in the wrong project.

Changes (the Community Specification policy structure — roles, consensus decision-making, ANSI due process, development process — is deliberately unchanged):

- Retitled and renamed the working group to the **SDLC Controls Framework**
- Voting enrollment now points at **sdlc-framework+subscribe@lists.finos.org**
- AIGF maintainer team links and `ai-gov-framework-maintainers@` contact replaced with **MAINTAINERS.md**
- Dropped the hardcoded "six Maintainers" count in favour of MAINTAINERS.md as the source of truth
- Fixed the dangling `./SCOPE` link in §4.4 to `./SCOPE.md` (added in #90)

Best reviewed alongside #90, which adds the SCOPE.md this document references.
