### PR TITLE
Adopt 'SDLC Common Controls Catalog' naming in prose

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-# Code of Conduct for SDLC Controls Framework
+# Code of Conduct for the SDLC Common Controls Catalog
 
 Please see the [Community Code of Conduct](https://www.finos.org/code-of-conduct).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to SDLC Controls Framework
+# Contributing to the SDLC Common Controls Catalog
 
-SDLC Controls Framework is licensed under a [Creative Commons Attribution 4.0 International License][cc-by] and accepts contributions via git pull requests.  Each commit must include a DCO line in the git commit message:
+The SDLC Common Controls Catalog is licensed under a [Creative Commons Attribution 4.0 International License][cc-by] and accepts contributions via git pull requests.  Each commit must include a DCO line in the git commit message:
 
 `Signed-off-by: GitHub User Name <your.email@example.com>`
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
-# SDLC Controls Framework Governance Policy
+# SDLC Common Controls Catalog Governance Policy
 
-This document provides the governance policy for the development of the SDLC Controls Framework specification and related materials (the “Working Group”).
+This document provides the governance policy for the development of the SDLC Common Controls Catalog specification and related materials (the “Working Group”).
 
 ## 1.	Roles.
 
@@ -8,18 +8,18 @@ The Working Group includes the following roles:
 
 ### 1.1. Participants
 
-“Participants” are those that have made Contributions to the Working Group subject to the [Community Specification Contribution Policy 1.0](https://spdx.org/licenses/Community-Spec-1.0.html).  The SDLC Controls Framework Working Group has the specific purpose of defining and releasing subsequent updates to the framework. In practice, that means people that attend and contribute to meetings, raise issues, pull requests (to submit patches to the framework) and reviews.
+“Participants” are those that have made Contributions to the Working Group subject to the [Community Specification Contribution Policy 1.0](https://spdx.org/licenses/Community-Spec-1.0.html).  The SDLC Common Controls Catalog Working Group has the specific purpose of defining and releasing subsequent updates to the catalog. In practice, that means people that attend and contribute to meetings, raise issues, pull requests (to submit patches to the catalog) and reviews.
 
 #### How do you become a Participant?
 
-Becoming a Participant is as easy as attending a meeting and/or raising issues for changes you'd like to see in the framework, commenting on issues others have raised or even asking questions (which can often result in the clarification of the framework's documentation to help others with the same questions in future).
+Becoming a Participant is as easy as attending a meeting and/or raising issues for changes you'd like to see in the catalog, commenting on issues others have raised or even asking questions (which can often result in the clarification of the catalog's documentation to help others with the same questions in future).
 
 #### Register to vote
-Participants may register to vote on changes to the SDLC Controls Framework (see [Section 2](#2decision-making) below). To do so, register to the group by sending an empty email to [sdlc-framework+subscribe@lists.finos.org](mailto:sdlc-framework+subscribe@lists.finos.org) to join the enrolled voting participants group.
+Participants may register to vote on changes to the SDLC Common Controls Catalog (see [Section 2](#2decision-making) below). To do so, register to the group by sending an empty email to [sdlc-framework+subscribe@lists.finos.org](mailto:sdlc-framework+subscribe@lists.finos.org) to join the enrolled voting participants group.
 
 ### 1.2. Discussion Groups
 
-The Working Group may form one or more "Discussion Groups" to organize collaboration around a particular aspect of a specification. Discussion Groups are for discussion only.  Approval of all portions of a specification is subject to the consensus-based decision-making process of the SDLC Controls Framework Working Group.
+The Working Group may form one or more "Discussion Groups" to organize collaboration around a particular aspect of a specification. Discussion Groups are for discussion only.  Approval of all portions of a specification is subject to the consensus-based decision-making process of the SDLC Common Controls Catalog Working Group.
 
 ### 1.3. Maintainers 
 
@@ -27,7 +27,7 @@ The Working Group may form one or more "Discussion Groups" to organize collabora
 
 #### How do you become a Maintainer?
 
-Once you are an enrolled participant, you can apply to become a **maintainer** by contacting the existing maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) and then seeking the approval of the Working Group. Generally, the maintainers will look for both a history of contribution to the framework and a commitment to investing sufficient time in the role from any prospective candidates before proposing them to the Working Group for approval. 
+Once you are an enrolled participant, you can apply to become a **maintainer** by contacting the existing maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) and then seeking the approval of the Working Group. Generally, the maintainers will look for both a history of contribution to the catalog and a commitment to investing sufficient time in the role from any prospective candidates before proposing them to the Working Group for approval. 
 
 If you are new to the project, but willing to make the investment of time, the maintainers can work with you to build up a history of contribution.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-SDLC Controls Framework - FINOS
+SDLC Common Controls Catalog - FINOS
 Copyright 2025 FINOS - info@finos.org
 
 This product includes software developed at the Fintech Open Source Foundation (https://www.finos.org/).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![badge-labs](https://user-images.githubusercontent.com/327285/230928932-7c75f8ed-e57b-41db-9fb7-a292a13a1e58.svg)
 
-# SDLC Controls Framework
+# SDLC Common Controls Catalog
 
 > **[View the live site](https://finos-labs.github.io/SDLC-Controls-Framework/)**
 
-The SDLC Controls Framework Working Group aims to create a shared, open reference library for software governance controls across the financial services industry. By establishing common definitions, implementations, and patterns, we reduce duplication, prevent drift, and enable institutions to focus on innovation rather than reinventing control frameworks.
+The SDLC Common Controls Catalog Working Group aims to create a shared, open reference library for software governance controls across the financial services industry. By establishing common definitions, implementations, and patterns, we reduce duplication, prevent drift, and enable institutions to focus on innovation rather than reinventing control frameworks.
 
 
 
@@ -23,11 +23,11 @@ The financial services industry faces an increasingly complex regulatory landsca
 
 ## Our Solution
 
-A **composable, technology-agnostic controls catalogue** that provides:
+A **composable, technology-agnostic controls catalog** that provides:
 - **Common definitions** for SDLC controls used across financial services
 - **Reference implementations** with concrete patterns and examples
 - **Shared vocabulary** enabling clear communication between institutions, vendors, and regulators
-- **Flexible framework** where institutions can select applicable controls while maintaining their unique requirements
+- **Flexible catalog** where institutions can select applicable controls while maintaining their unique requirements
 
 ## Getting Started
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ mitigation_classification:
 
 # SDLC phase at which a mitigation primarily operates. LIFECYCLE is the
 # cross-cutting bucket for governance/process controls that are not tied to a
-# single phase. Used by the catalogue phase filter.
+# single phase. Used by the catalog phase filter.
 phase_classification:
   CODE: Code
   BUILD: Build
@@ -24,7 +24,7 @@ phase_classification:
   RUNTIME: Runtime
   LIFECYCLE: Lifecycle
 
-# Bootstrap Icons class for each classification code, used by the catalogue
+# Bootstrap Icons class for each classification code, used by the catalog
 # headings and filter checkboxes. Adding a new code above requires adding the
 # matching icon here.
 category_icons:

--- a/docs/_data/glossary.yml
+++ b/docs/_data/glossary.yml
@@ -1,4 +1,4 @@
-# Definitions of terms used across the SDLC Controls Framework.
+# Definitions of terms used across the SDLC Common Controls Catalog.
 # DRAFT — to be revisited. Rendered alphabetically by `definitions.md`.
 # Each entry: term, slug (anchor id), definition.
 
@@ -65,7 +65,7 @@
   slug: immutability
   definition: >-
     The property that, once recorded, something cannot be changed. In this
-    framework, history may be preserved either by strict immutability or by a
+    catalog, history may be preserved either by strict immutability or by a
     sufficient audit trail; the required property is that history cannot be
     altered or destroyed undetectably.
 
@@ -85,7 +85,7 @@
 - term: Regulatory guidance vs. industry standard
   slug: regulatory-guidance-vs-industry-standard
   definition: >-
-    A reference distinction used in this framework. Regulatory guidance is issued
+    A reference distinction used in this catalog. Regulatory guidance is issued
     by regulators (for example the FFIEC IT Handbook); industry standards are
     voluntary, consensus-based frameworks (for example NIST, ISO/IEC, SLSA).
 
@@ -94,13 +94,13 @@
   definition: >-
     A release is a version of software made available for production; deployment
     is the act of placing software into an environment; promotion is moving a
-    build forward through environments toward production. The framework uses
+    build forward through environments toward production. The catalog uses
     "released to production" for the point software goes live.
 
 - term: Risk
   slug: risk
   definition: >-
-    An undesirable outcome the framework seeks to reduce. Each risk is addressed
+    An undesirable outcome the catalog seeks to reduce. Each risk is addressed
     by one or more mitigations (controls).
 
 - term: Tamper-evident history

--- a/docs/_data/iso-iec-27002.yml
+++ b/docs/_data/iso-iec-27002.yml
@@ -1,6 +1,6 @@
 # ISO/IEC 27002:2022 — Information security controls
 # Hand-maintained: the standard text is paywalled, so entries link to the
-# ISO catalogue page for the standard rather than to per-control text.
+# ISO catalog page for the standard rather than to per-control text.
 # Source: https://www.iso.org/standard/75652.html
 
 8-4:

--- a/docs/_includes/catalogue.html
+++ b/docs/_includes/catalogue.html
@@ -113,14 +113,14 @@
     </div>
 </div>
 
-<!-- Main Catalogue Cards -->
+<!-- Main Catalog Cards -->
 <div class="row mb-5" id="catalogueRow">
     <div class="col-md-6">
         <div class="card h-100 shadow border-0">
             <div class="card-header bg-primary text-white">
                 <div class="d-flex justify-content-between align-items-center">
                     <h2 class="h4 mb-0">
-                        <i class="bi bi-asterisk me-2"></i>Risk Catalogue
+                        <i class="bi bi-asterisk me-2"></i>Risk Catalog
                     </h2>
                     <button class="btn btn-outline-light btn-sm expand-btn" type="button" data-catalogue="risk">
                         <i class="bi bi-chevron-bar-right"></i>
@@ -203,7 +203,7 @@
             <div class="card-header bg-success text-white">
                 <div class="d-flex justify-content-between align-items-center">
                     <h2 class="h4 mb-0">
-                        <i class="bi bi-shield-shaded me-2"></i>Mitigation Catalogue
+                        <i class="bi bi-shield-shaded me-2"></i>Mitigation Catalog
                     </h2>
                     <button class="btn btn-outline-light btn-sm expand-btn" type="button" data-catalogue="mitigation">
                         <i class="bi bi-chevron-bar-left"></i>
@@ -332,7 +332,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const riskVisible = !catalogueStates.mitigation.expanded && (selectedType !== 'mitigation');
         const mitigationVisible = !catalogueStates.risk.expanded && (selectedType !== 'risk');
         
-        // Handle Risk Catalogue
+        // Handle Risk Catalog
         if (!riskVisible) {
             riskColumn.style.display = 'none';
         } else {
@@ -340,7 +340,7 @@ document.addEventListener('DOMContentLoaded', function() {
             riskColumn.className = catalogueStates.risk.expanded || !mitigationVisible ? 'col-12' : 'col-md-6';
         }
         
-        // Handle Mitigation Catalogue
+        // Handle Mitigation Catalog
         if (!mitigationVisible) {
             mitigationColumn.style.display = 'none';
         } else {

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -6,13 +6,13 @@
     
     <!-- HTML Meta Tags -->
     <title>FINOS SDLC3: {{ title }}</title>
-    <meta name="description" content="Adopt and deploy AI with confidence. Open-source AI governance framework for financial services.">
+    <meta name="description" content="A shared, open catalog of software delivery risks and controls for financial services.">
 
     <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://air-governance-framework.finos.org">
+    <meta property="og:url" content="https://finos-labs.github.io/SDLC-Controls-Framework/">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="FINOS AI Governance Framework">
-    <meta property="og:description" content="Adopt and deploy AI with confidence. Open-source AI governance framework for financial services.">
+    <meta property="og:title" content="FINOS SDLC Common Controls Catalog">
+    <meta property="og:description" content="A shared, open catalog of software delivery risks and controls for financial services.">
     <meta property="og:image" content="{{ site.baseurl }}/sdlc_logo.png">
 
 

--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -5,7 +5,7 @@ layout: default
 <header class="py-5 bg-light border-bottom">
     <div class="container">
         <div class="d-flex align-items-center">
-            <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Controls Framework Icon" style="height: 72px;" class="me-3 mb-0">
+            <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Common Controls Catalog Icon" style="height: 72px;" class="me-3 mb-0">
             <div>
                 <h1 class="display-4 mb-0">{{ page.title }}</h1>
             </div>

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -9,14 +9,14 @@ layout: default
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
                 </svg>
-                Back to Mitigation Catalogue
+                Back to Mitigation Catalog
             </a>
         </div>
         <div class="mitigation-id mb-2">{% include mitigation-id.html mitigation=page %}</div>
         <div class="container">
             <div class="d-flex align-items-center justify-content-between">
                 <div class="d-flex align-items-center">
-                    <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Controls Framework Icon" style="height: 72px;" class="me-3 mb-0">
+                    <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Common Controls Catalog Icon" style="height: 72px;" class="me-3 mb-0">
                     <div>
                         <h1 class="display-4 mb-0">{{ page.title }}</h1>
                     </div>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -9,11 +9,11 @@ layout: default
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
                 </svg>
-                Back to Catalogue
+                Back to Catalog
             </a>
         </div>
         <div class="d-flex align-items-center">
-            <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Controls Framework Icon" style="height: 72px;" class="me-3 mb-0">
+            <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Common Controls Catalog Icon" style="height: 72px;" class="me-3 mb-0">
             <div>
                 <h1 class="display-4 mb-0">{{ page.title }}</h1>
                 {% if page.subtitle %}<p class="lead mb-0">{{ page.subtitle }}</p>{% endif %}

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -9,14 +9,14 @@ layout: default
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
                 </svg>
-                Back to Risk Catalogue
+                Back to Risk Catalog
             </a>
         </div>
         <div class="risk-id mb-2">{% include risk-id.html risk=page %}</div>
         <div class="container">
             <div class="d-flex align-items-center justify-content-between">
                 <div class="d-flex align-items-center">
-                    <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Controls Framework Icon" style="height: 72px;" class="me-3 mb-0">
+                    <img src="{{ site.baseurl }}/sdlc_logo.png" alt="SDLC Common Controls Catalog Icon" style="height: 72px;" class="me-3 mb-0">
                     <div>
                         <h1 class="display-4 mb-0">{{ page.title }}</h1>
                     </div>

--- a/docs/_mitigations/mi-12_deployment-gating.md
+++ b/docs/_mitigations/mi-12_deployment-gating.md
@@ -32,7 +32,7 @@ Deployment gating blocks promotion of software to the target environment when de
 
 ## Description
 
-Deployment gating enforces policy-based decisions at the point of deployment to ensure that only software meeting defined control criteria is promoted to production. Gates evaluate the posture of an artefact against the organisation's defined policies and block deployment when criteria are not met. Without deployment gates, other controls in the framework are advisory only, and non-compliant software may reach the target environment despite known issues. In regulated financial services environments, deployment gating provides auditable evidence that organisational policy was enforced at every release.
+Deployment gating enforces policy-based decisions at the point of deployment to ensure that only software meeting defined control criteria is promoted to production. Gates evaluate the posture of an artefact against the organisation's defined policies and block deployment when criteria are not met. Without deployment gates, other controls in the catalog are advisory only, and non-compliant software may reach the target environment despite known issues. In regulated financial services environments, deployment gating provides auditable evidence that organisational policy was enforced at every release.
 
 ## Requirements
 

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -1,13 +1,13 @@
 ---
 layout: page
 title: "Definitions of Terms"
-subtitle: "What we mean by some of the framework's more nuanced terms"
+subtitle: "What we mean by some of the catalog's more nuanced terms"
 draft: true
 ---
 
 <p class="text-muted">
-This glossary explains terms used across the risk and mitigation catalogue that
-carry a specific meaning in this framework, or that are easy to misread. It is a
+This glossary explains terms used across the risk and mitigation catalog that
+carry a specific meaning in this catalog, or that are easy to misread. It is a
 living document.
 </p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,6 @@ To meet these expectations, SDLC processes must incorporate robust controls that
 
 This project aims to present a curated set of common risks encountered during the SDLC, along with their corresponding mitigations. By establishing a standardized library of controls, the goal is to streamline compliance efforts, reduce uncertainty, and promote safe, repeatable development practices aligned with regulatory expectations.
 
-New to the terminology? See the [Definitions of Terms]({{ site.baseurl }}/definitions.html) for what we mean by the framework's more nuanced language.
+New to the terminology? See the [Definitions of Terms]({{ site.baseurl }}/definitions.html) for what we mean by the catalog's more nuanced language.
 
 {% include catalogue.html %}


### PR DESCRIPTION
We are moving away from describing the project as a framework; the name in the FINOS proposal ([finos/community#425](https://github.com/finos/community/issues/425)) is the **SDLC Common Controls Catalog**. This renames the prose references across the repo — 14 files, 31 lines: README, GOVERNANCE.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, NOTICE, site layouts (logo alt text), glossary, definitions page, and one control (mi-12's reference to "controls in the framework").

**Deliberately unchanged:** the repository name and all URLs, the `sdlc-framework` mailing list address, the historical OSFF NY talk title, and generic uses of the word (change-management frameworks, NIST SSDF, "framework-agnostic", external standards tables).

**Bonus fix:** `docs/_layouts/default.html` still carried the AI Governance Framework's social-media metadata — link previews of our site were titled "FINOS AI Governance Framework" with og:url pointing at air-governance-framework.finos.org. Now titled and described as the SDLC Common Controls Catalog with the correct URL.