### PR TITLE
Introduce meta controls and tag MI-22 as a meta control

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,13 +16,16 @@ mitigation_classification:
 
 # SDLC phase at which a mitigation primarily operates. LIFECYCLE is the
 # cross-cutting bucket for governance/process controls that are not tied to a
-# single phase. Used by the catalog phase filter.
+# single phase. META marks "meta controls" — controls whose subject is the
+# operation of other controls rather than a specific SDLC phase (see the
+# glossary). Used by the catalog phase filter.
 phase_classification:
   CODE: Code
   BUILD: Build
   RELEASE: Release
   RUNTIME: Runtime
   LIFECYCLE: Lifecycle
+  META: Meta
 
 # Bootstrap Icons class for each classification code, used by the catalog
 # headings and filter checkboxes. Adding a new code above requires adding the
@@ -39,6 +42,7 @@ category_icons:
   RELEASE: bi-rocket-takeoff-fill
   RUNTIME: bi-play-circle-fill
   LIFECYCLE: bi-arrow-repeat
+  META: bi-layers-fill
 
 document_status:
   - name: Pre-Draft

--- a/docs/_data/glossary.yml
+++ b/docs/_data/glossary.yml
@@ -69,11 +69,24 @@
     sufficient audit trail; the required property is that history cannot be
     altered or destroyed undetectably.
 
+- term: Meta control
+  slug: meta-control
+  definition: >-
+    A control whose subject is the operation of other controls rather than a
+    specific SDLC risk directly — a "control over controls". Meta controls are
+    cross-cutting: they govern how the catalog's controls are managed,
+    evidenced, and overseen rather than preventing or detecting a single
+    undesirable outcome. Examples include managed control exceptions (oversight
+    and visibility of approved deviations) and evidence retention (approved
+    stores and a defined retention strategy). Distinct from a mitigation, which
+    reduces one or more named risks.
+
 - term: Mitigation (Control)
   slug: mitigation-control
   definition: >-
     A control that reduces one or more risks. "Mitigation" and "control" are used
-    interchangeably; each mitigation references the risks it addresses.
+    interchangeably; each mitigation references the risks it addresses. See also
+    Meta control, a control whose subject is other controls rather than a risk.
 
 - term: Provenance
   slug: provenance

--- a/docs/_mitigations/mi-22_data-retention.md
+++ b/docs/_mitigations/mi-22_data-retention.md
@@ -4,7 +4,7 @@ title: Data Retention and Disposal
 layout: mitigation
 doc-status: Draft
 type: PREV
-phase: LIFECYCLE
+phase: META
 nist-sp-800-53r5_references:
   - au-11  # AU-11 Audit Record Retention
   - mp-6   # MP-6 Media Sanitization

--- a/docs/style.css
+++ b/docs/style.css
@@ -93,6 +93,25 @@
     box-shadow: 0 2px 15px rgba(25, 135, 84, 0.15) !important;
 }
 
+/* Meta controls — cross-cutting "controls over controls" (phase: META).
+   Distinguished from phase-scoped mitigations by a tasteful purple accent. */
+.mitigation-item[data-phase="META"] .card.border-success {
+    border-left-color: #6f42c1 !important;
+}
+
+.mitigation-item[data-phase="META"] .card:hover {
+    box-shadow: 0 2px 15px rgba(111, 66, 193, 0.18) !important;
+}
+
+.mitigation-item[data-phase="META"] .mitigation-id {
+    color: #6f42c1;
+}
+
+/* Tint the Meta phase filter icon to match the card accent. */
+label[for="phase-META"] i {
+    color: #6f42c1;
+}
+
 /* Clickable card styling */
 .card-hover {
     cursor: pointer;


### PR DESCRIPTION
## What

Introduces the concept of a **meta control** to the SDLC Common Controls Catalog — a control whose subject is the operation of *other* controls, rather than a specific SDLC risk directly.

Meta controls were raised as a gap at the June 2026 OSFF workshop and appear on the roadmap ("managed control exceptions" and "evidence retention"), but the concept itself had never been defined in the catalog. This defines it, makes it filterable, and applies it to the one existing control that already fits.

## Changes

| File | Change |
| --- | --- |
| `docs/_data/glossary.yml` | Define **Meta control**; cross-reference it from the existing *Mitigation (Control)* entry |
| `docs/_config.yml` | Add `META: Meta` to `phase_classification` + a `bi-layers-fill` icon |
| `docs/style.css` | Purple (`#6f42c1`) accent for meta controls — left border, hover shadow, control id, filter icon |
| `docs/_mitigations/mi-22_data-retention.md` | `phase: LIFECYCLE` → `phase: META` |

Modelling meta as a **phase** means the catalog's existing *Filter by Phase* control picks it up automatically — no changes to the filter markup or JavaScript were needed, since the filter iterates `phase_classification` and the cards already carry `data-phase`.

## Why MI-22

MI-22 Data Retention and Disposal already describes itself as a control over other controls:

> Each of these is produced by a more specific mitigation elsewhere in this catalogue [...] This mitigation is the general policy those records are governed by. It does not replace the record producing controls; it sets how long their output must be kept.

That is a control-over-controls, and it matches the roadmap's "evidence retention" example.

## Scope — what is deliberately unchanged

- **MI-14 Test Evidence Retention stays at `BUILD`.** It retains the output of one phase-scoped control and is itself governed by MI-22, so it is the specific control rather than the meta one.
- **The remaining `LIFECYCLE` controls stay as they are** (Requirements Repository, System Inventory, Testing Requirements, Vulnerability Remediation SLAs). They span the lifecycle but act on the SDLC directly rather than on other controls.

This leaves a clean split: **META** = controls whose subject is other controls; **LIFECYCLE** = controls that span the whole lifecycle but act on the SDLC directly. Worth a working-group sanity check, since the two are adjacent — if the group would rather META subsume the governance end of LIFECYCLE, that is a one-line config change.

## Verification

Built and served locally with Jekyll 4.3.4 (`bundle exec jekyll serve`) and confirmed in the generated output:

- the **Meta** checkbox renders under *Filter by Phase* with the layers icon
- exactly one card carries `data-phase="META"` (MI-22), and filtering on Meta narrows to it
- MI-22 renders with the purple accent while all other controls stay green
- the *Meta control* glossary entry renders at `definitions.html#meta-control`

## Follow-ups (not in this PR)

The two meta controls named on the roadmap still need authoring — managed control exceptions, and an evidence-retention control if the group wants one distinct from MI-22.