### PR TITLE
Re-tag MI-2 as a meta control and reframe it around evidence references

### DIFF
--- a/docs/_mitigations/mi-2_content-addressable-identities.md
+++ b/docs/_mitigations/mi-2_content-addressable-identities.md
@@ -4,41 +4,70 @@ title: Content Addressable Identities
 layout: mitigation
 doc-status: Draft
 type: PREV
-phase: BUILD
+phase: META
 nist-sp-800-53r5_references:
   - si-7   # SI-7 Software, Firmware, And Information Integrity
   - sa-10  # SA-10 Developer Configuration Management
   - au-10  # AU-10 Non-repudiation
 mitigates:
   - ri-1   # Insider Threat
+  - ri-5   # Audit and Compliance Evidence Failure
   - ri-7   # Configuration Drift
   - ri-11  # Build Toolchain and Service Supply Chain Compromise
 related_mitigations:
-  - mi-3  # Binary Provenance
-  - mi-1  # Peer Source Code Review
+  - mi-3   # Software Artifact Provenance
+  - mi-8   # Version Control
+  - mi-14  # Test Evidence Retention
+  - mi-1   # Peer Source Code Review
+  - mi-22  # Data Retention and Disposal
 ---
 
 ## Summary
 
-Software artifacts are identified by cryptographic hashes of their contents, ensuring that any change to an artifact produces a different identity and making tampering immediately detectable.
+Where a control's evidence refers to the subject it is evidence about, that reference must be a cryptographic hash of the subject's content, so that the binding between evidence and subject cannot be broken after the fact.
 
 ## Description
 
-High-security environments require a tamper-proof identity scheme for software artifacts (e.g. compiled binaries, container images, JAR files, npm packages, Helm charts, configuration bundles). Content addressable identification uses cryptographic hashing (e.g., SHA-256) to derive an artifact's identity directly from its contents. Unlike mutable labels such as version tags or filenames, these identities are immutable: even a single-byte change produces a completely different hash. This provides the foundation for verifiable integrity of binaries, containers, packages, and other deliverables throughout the software development lifecycle.
+Every control in this catalogue produces evidence about a subject. A peer review ([SDLC-PREV-001]({% link _mitigations/mi-1_code-review.md %})) is evidence about a source revision. A static analysis scan ([SDLC-PREV-005]({% link _mitigations/mi-5_vulnerability-scanning-sast.md %})) is evidence about a state of the codebase. Test evidence ([SDLC-PREV-014]({% link _mitigations/mi-14_test-evidence.md %})) is evidence about a build. A provenance record ([SDLC-PREV-003]({% link _mitigations/mi-3_software-artifact-provenance.md %})) is evidence about an artifact. A release approval ([SDLC-PREV-019]({% link _mitigations/mi-19_version-approval.md %})) is evidence about a version. In every case the evidence is worth no more than the reference that ties it to its subject.
 
-Human-readable identifiers (semantic versions, branch names, commit references) remain useful for navigation and convenience but must never be relied upon for security or compliance verification.
+Where that reference is a mutable label — a version tag, a branch name, a filename, a build number, an environment name — the binding can be broken without touching the evidence. The label is reassigned to different content, and the evidence silently becomes a claim about something it was never about. Nothing in the record changes, so nothing appears wrong: the control still shows as having operated, and the evidence it produced no longer means what it says. This is a failure mode that reviewing the evidence cannot detect, because the evidence is not what changed.
+
+Content addressable identification closes this gap by deriving the subject's identity from its content, using a cryptographic hash such as SHA-256. Any change to the content produces a different identity, so a reference by hash cannot be re-pointed. It resolves to exactly the content that was examined, or it does not resolve at all, and either outcome is detectable.
+
+This is why the control is classified as a meta control rather than sitting at a single SDLC phase. It does not prevent or detect a specific undesirable outcome by itself; it is the property that makes the evidence produced by other controls dependable. Build outputs are the most familiar application, but the same requirement applies to source revisions at CODE, to approvals at RELEASE, and to the inventories and evidence stores that span the lifecycle.
+
+Human-readable identifiers — semantic versions, tags, branch names, environment names — remain necessary for navigation, communication, and day-to-day operation. They must not be the reference of record where that reference carries security or compliance weight.
 
 ## Requirements
 
-* Every software artifact MUST be identified by a cryptographic hash (SHA-256 or stronger) of its contents
-* Any modification to an artifact MUST produce a completely different identity
-* Content addressable identities MUST be immutable and cannot be forged or reassigned to different content
-* All systems that store, transfer, or deploy artifacts MUST reference them by their cryptographic identity
+* **Content-Derived Identity** — A subject MUST be identifiable by a cryptographic hash computed over its content, such that any modification to the content produces a different identity.
+* **Collision-Resistant Algorithm** — The hash algorithm MUST be SHA-256 or stronger. Algorithms with known practical collision attacks, such as MD5 and SHA-1, MUST NOT be used where the identity carries security or compliance weight.
+* **Recorded Algorithm** — The algorithm MUST be recorded alongside the digest, so that an identity remains independently verifiable and can be migrated when an algorithm is deprecated.
+* **Fingerprint References in Evidence** — Where a control's record, report, attestation, or approval refers to its subject, it MUST identify that subject by content addressable identity. Human-readable identifiers MAY be recorded alongside, but MUST NOT be the only reference.
+* **Verifiable on Use** — A system that acts on a subject by its content addressable identity MUST be able to recompute the hash from the content and confirm it matches before relying on it.
+* **Preserved Across Handoffs** — The identity MUST be carried unchanged as a subject moves between systems, pipeline stages, and organisational boundaries. A downstream system MUST NOT substitute a mutable label for the identity it received.
 
 ## Examples & Commentary
 
-* Generate SHA-256 hashes for all build outputs including container images, compiled binaries, archives, and packages
-* Configure container registries and artifact repositories to use content-addressable storage (e.g., Docker content trust, OCI image digests)
-* CI/CD pipelines should propagate cryptographic identities rather than mutable tags when referencing artifacts across stages
-* Implement verification checks at deployment boundaries that confirm the cryptographic identity of an artifact before allowing it to proceed
-* Store artifact hashes in a secure, append-only record that serves as the source of truth for artifact identity
+* **Source revisions are already content addressable:** A Git commit ID is a hash over the tree and the parent chain, so citing a review or scan result by commit SHA rather than by branch name gives that evidence a subject that cannot be reassigned. Referring to `main` instead records only where a branch pointer happened to be at the time. [SDLC-PREV-008]({% link _mitigations/mi-8-version-control.md %}) covers the integrity of the history those identities are drawn from.
+
+* **Container images:** OCI registries support digest references (`registry/app@sha256:...`) alongside mutable tags. Deployment manifests and admission policies should pin by digest — a tag, including a semantic version tag, can be re-pushed to point at different image content, whereas a digest cannot.
+
+* **Packages and dependencies:** Lockfiles are the usual mechanism for holding dependency digests: npm `integrity` fields, `go.sum`, `Cargo.lock`, Maven checksums. A component inventory ([SDLC-PREV-009]({% link _mitigations/mi-9-component-inventory.md %})) that lists only names and versions cannot support the claim that the inventory describes what was actually built.
+
+* **Evidence naming its subject:** A test report should record the digest of the build under test rather than a CI build number. Where the build number is the only identifier, the evidence cannot be re-bound to its subject once the CI system's own records age out under retention policy ([SDLC-PREV-022]({% link _mitigations/mi-22_data-retention.md %})).
+
+* **Where a mutable label is unavoidable:** Operational workflows legitimately need names such as release tags and `latest`. Where they are used, the mapping from label to digest should itself be recorded immutably, so that the mapping in force at a given point in time can be reconstructed rather than inferred. [SDLC-PREV-003]({% link _mitigations/mi-3_software-artifact-provenance.md %}) covers this binding for build artifacts.
+
+* **Verification at boundaries:** Deployment gates and admission controllers ([SDLC-PREV-012]({% link _mitigations/mi-12_deployment-gating.md %})) are the natural enforcement points for the verifiable-on-use property: recompute or confirm the digest before admitting the subject, rather than trusting the reference that accompanied it.
+
+* **Algorithm migration:** Recording the algorithm alongside the digest is what makes migration possible without invalidating historical evidence. Git's ongoing move from SHA-1 to SHA-256 object identities is the clearest example of why the algorithm cannot be left implicit.
+
+## Links
+
+- [FIPS 180-4: Secure Hash Standard](https://csrc.nist.gov/pubs/fips/180-4/upd1/final)
+- [NIST SP 800-53r5 SI-7: Software, Firmware, and Information Integrity](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 SA-10: Developer Configuration Management](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [NIST SP 800-53r5 AU-10: Non-repudiation](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+- [OCI Image Specification: Descriptors and digests](https://github.com/opencontainers/image-spec/blob/main/descriptor.md)
+- [Git Internals: Git Objects](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects)


### PR DESCRIPTION
## Summary

Re-tags **MI-2 Content Addressable Identities** from `BUILD` to `META`, and reframes the control body to match.

MI-2 was written as an artifact control: the requirements spoke only about build outputs, and the commentary about hashing them. But content addressable identity is not a property of the build phase. It is the property that lets *any* control's evidence name its subject unambiguously — a review naming a source revision, a scan naming a codebase state, an approval naming a version.

Where that reference is a mutable label rather than a digest, the binding can be broken without altering the evidence, and reviewing the evidence cannot detect the change — because the evidence is not what changed. That makes MI-2 a control over other controls rather than a phase control, so it joins MI-22 under `META` (introduced in #97).

The `BUILD` phase keeps MI-3, which owns the binding of an artifact's digest to its source and build metadata. MI-2 now states the identity property that binding relies on. No other control is re-tagged.

## Changes

- **Phase** — `BUILD` → `META`
- **Summary and Description** — reframed around the evidence-to-subject reference, naming the controls that depend on it (MI-1, MI-3, MI-5, MI-14, MI-19)
- **Requirements** — restructured as named, testable properties. Replaces the circular *"MUST be immutable and cannot be forged or reassigned to different content"* with **Content-Derived Identity**, **Collision-Resistant Algorithm** and **Recorded Algorithm**, which state what has to hold and can be checked. The artifact-only reference requirement generalises into **Fingerprint References in Evidence**, **Verifiable on Use** and **Preserved Across Handoffs**.
- **Examples & Commentary** — now spans the lifecycle rather than build outputs: Git commit IDs as already content addressable, OCI digests vs re-pushable tags, lockfile digests, evidence naming its subject instead of a CI build number, the label-to-digest mapping, verification at deployment gates, and algorithm migration
- **`## Links`** — added; this section was missing and was the readiness blocker flagged in #96
- **`mitigates`** — added `ri-5` Audit and Compliance Evidence Failure, which under this framing is the risk MI-2 most directly addresses. `ri-1`, `ri-7`, `ri-11` unchanged.
- **`related_mitigations`** — expanded with MI-8, MI-14 and MI-22 to reflect the cross-cutting scope

## Verification

- `scripts/lint-check` passes
- `scripts/readiness-check` reports MI-2 **ready** — it previously failed on the missing `## Links` section, the blocker recorded against MI-2 in the Mitigation Review Tracker (#96)
- `make build` succeeds and resolves all nine new `{% link %}` cross-references, with correct single-baseurl URLs
- The catalogue emits `data-phase="META"` for MI-2, so the Meta phase filter now lists MI-2 alongside MI-22

## Notes for reviewers

Three changes go slightly beyond a phase re-tag, called out for a working-group view:

1. Adding `ri-5` to `mitigates` is a risk-mapping judgement, not a mechanical consequence of the re-tag.
2. Adding `## Links` fixes the #96 readiness blocker in passing. Happy to split it out if the working group would rather review the re-tag alone.
3. The `Fingerprint References in Evidence` requirement is deliberately scoped to *how evidence names its subject*. It does not take over MI-3's tag-to-digest mapping, which stays where it is and is cross-referenced instead.

**Still outstanding against the MI-8 exemplar, not addressed here:** the frontmatter carries only three bare NIST 800-53 IDs with no `note:` annotations. MI-8 annotates every reference across five frameworks, and SSDF `ps-1`/`ps-3`, ISO 27002, FFIEC and SLSA all have plausible mappings for MI-2. That work needs new entries in the hand-maintained `docs/_data/*.yml` files plus a checksum refresh, so it is better as a follow-up.

**Two pre-existing issues noticed while working, unrelated to this change:** `docs/_data/iso-iec-27002.yml` fails its recorded checksum on a clean tree, and `readiness-report.md` is stale (dated 2026-06-20, still reports `mi-1` as non-existent).

Refs #96
