### PR TITLE
Rework MI-19 as Release Approval Gating; sharpen the MI-12 boundary

### DIFF
--- a/docs/_mitigations/mi-12_deployment-gating.md
+++ b/docs/_mitigations/mi-12_deployment-gating.md
@@ -16,6 +16,7 @@ mitigates:
   - ri-4   # Vulnerable Software in Production
   - ri-9   # Environment Breach
 related_mitigations:
+  - mi-19  # Release Approval Gating
   - mi-5   # Vulnerability Scanning - SAST
   - mi-6   # Vulnerability Scanning - DAST
   - mi-7   # Vulnerability Scanning - Dependencies
@@ -34,13 +35,13 @@ Deployment gating blocks promotion of software to the target environment when de
 
 Deployment gating enforces policy-based decisions at the point of deployment to ensure that only software meeting defined control criteria is promoted to production. Gates evaluate the posture of an artefact against the organisation's defined policies and block deployment when criteria are not met. Without deployment gates, other controls in the catalog are advisory only, and non-compliant software may reach the target environment despite known issues. In regulated financial services environments, deployment gating provides auditable evidence that organisational policy was enforced at every release.
 
+Deployment gating evaluates the current technical posture of an artefact at each deployment event — the same version can pass today and be blocked tomorrow as new findings emerge, scans age, or remediation timelines are breached. Whether the release itself has received organisational approval is governed by release approval gating ([mi-19]({% link _mitigations/mi-19_version-approval.md %})); that approval state is one of the conditions a deployment gate verifies.
+
 ## Requirements
 
 * Deployment gating policies MUST be defined to specify which conditions block deployment, based on the organisation's risk appetite and regulatory requirements
 * Gating policies MUST be configurable per application or service to allow organisations to tailor risk thresholds (e.g., stricter policies for internet-facing applications, adjusted thresholds for internal tools)
-* A documented override and emergency deployment process MUST exist for situations where deployment is critical despite unmet gate conditions. Overrides MUST require approval from an appropriate authority, include documented justification, and be time-bound
-* Overrides MUST be logged and auditable, including who approved, the justification, and the conditions that were bypassed
-* Gate evaluation results — including pass/fail status, which checks were evaluated, and any overrides — MUST be retained as part of the deployment record
+* Gate evaluation results — including pass/fail status and which checks were evaluated — MUST be retained as part of the deployment record
 * Gating policies MUST be reviewed and updated at least annually, or when significant changes to the threat landscape, regulatory requirements, or technology stack occur
 
 ## Examples & Commentary
@@ -48,9 +49,8 @@ Deployment gating enforces policy-based decisions at the point of deployment to 
 * **Policy Examples:** An organisation might define the following deployment gates: no new critical or high SAST findings; no critical CVEs in dependencies without an approved waiver; DAST scan completed within the last 14 days; no secrets detected in the codebase. The specific policies will vary by organisation and risk appetite
 * **Pipeline Enforcement:** Implement gates as required steps in the CI/CD pipeline. For example, a deployment job queries the vulnerability management platform for the artefact's security posture and proceeds only if all gate conditions are satisfied
 * **Graduated Policies:** Apply different gate strictness by environment and application criticality. A development environment might allow deployment with medium findings, while production for a customer-facing application blocks on anything high or above
-* **Emergency Overrides:** Define an emergency deployment process for genuinely urgent situations (e.g., a critical production outage fix). The override should require real-time approval from a security lead or on-call manager, be time-limited, and automatically create a follow-up ticket to address the bypassed condition
 * **Visibility & Feedback:** When a deployment is blocked, provide clear and actionable feedback to the engineering team: which gate failed, what findings caused the failure, and what actions are needed to proceed. Poor feedback loops lead to frustration and incentivise workarounds
-* **Relationship to Remediation SLAs:** Deployment gating works hand-in-hand with Remediation SLAs ([SDLC-PREV-011]({% link _mitigations/mi-11_vulnerability-remediation-slas.md %})). SLAs define *when* findings must be remediated; gates enforce that deployments cannot proceed when those timelines are breached. For example, a high-severity SAST finding with a 7-day SLA may not block deployment on day 1, but will block it on day 8 if unresolved
+* **Relationship to Remediation SLAs:** Deployment gating works hand-in-hand with Remediation SLAs ([mi-11]({% link _mitigations/mi-11_vulnerability-remediation-slas.md %})). SLAs define *when* findings must be remediated; gates enforce that deployments cannot proceed when those timelines are breached. For example, a high-severity SAST finding with a 7-day SLA may not block deployment on day 1, but will block it on day 8 if unresolved
 
 ## Links
 

--- a/docs/_mitigations/mi-19_version-approval.md
+++ b/docs/_mitigations/mi-19_version-approval.md
@@ -1,6 +1,6 @@
 ---
 sequence: 19
-title: Version Release Approval Gating
+title: Release Approval Gating
 layout: mitigation
 doc-status: Draft
 type: PREV
@@ -74,11 +74,11 @@ related_mitigations:
 
 ## Summary
 
-Version Release Approval Gating ensures that no software version is promoted to production without satisfying a defined approval process, enforced by designated human approvers, automated policy checks, or a combination of both. It establishes a verifiable, auditable gate at the version level — distinct from per-deployment gates — that confirms the release candidate has satisfied all governance, quality, and risk requirements before any deployment is permitted.
+Release Approval Gating ensures that no versioned release — a software artifact, an infrastructure-as-code change set, or both — is promoted to production without satisfying a defined approval process, enforced by designated human approvers, automated policy checks, or a combination of both. It establishes a verifiable, auditable gate at the release level — distinct from per-deployment gates — that confirms the release candidate has satisfied all governance, quality, and risk requirements before any deployment is permitted.
 
 ## Description
 
-Deployment gating ([mi-12]({% link _mitigations/mi-12_deployment-gating.md %})) controls whether an individual deployment job may proceed based on technical policy checks. Version Release Approval Gating operates at a higher level: it governs whether a named software version has received the organisational approval required to be released at all. A version may pass all automated deployment gates but still require explicit sign-off from a release manager, risk officer, or compliance stakeholder before it can be promoted from a candidate to an approved release.
+Deployment gating ([mi-12]({% link _mitigations/mi-12_deployment-gating.md %})) controls whether an individual deployment job may proceed based on technical policy checks. Release Approval Gating operates at a higher level: it governs whether a named release has received the organisational approval required to be released at all. A version may pass all automated deployment gates but still require explicit sign-off from a release manager, risk officer, or compliance stakeholder before it can be promoted from a candidate to an approved release.
 
 This distinction is critical in regulated financial services environments where change management frameworks require named human accountability for production releases, not merely automated technical policy satisfaction.
 
@@ -94,7 +94,7 @@ In either case, the approval state is recorded at the version level in a system 
 
 ## Requirements
 
-* Every software version intended for production MUST be subject to a defined approval process before any production deployment is initiated
+* Every versioned release intended for production MUST be subject to a defined approval process before any production deployment is initiated
 * Production deployment of a version MUST be technically prevented while the required approval for that version is absent or has been revoked
 * The approval process MUST specify which approver roles or automated checks are required, differentiated by application risk classification where appropriate
 * Manual approvals MUST be attributed to a named individual, timestamped, and recorded in an auditable system of record

--- a/docs/_mitigations/mi-19_version-approval.md
+++ b/docs/_mitigations/mi-19_version-approval.md
@@ -5,58 +5,120 @@ layout: mitigation
 doc-status: Draft
 type: PREV
 phase: RELEASE
-
+nist-sp-800-53r5_references:
+  - cm-3   # CM-3 Configuration Change Control
+  - cm-5   # CM-5 Access Restrictions for Change
+  - ca-6   # CA-6 Authorization
+eu-dora_references:
+  - id: dora-art-9-4-e
+    note: >
+      The parent DORA obligation: documented ICT change management policies
+      following a risk-based approach. A defined, version-level approval
+      process with named accountability is a direct implementation of that
+      policy for software releases.
+  - id: rts-art-16-2
+    note: >
+      Requires ICT systems to be tested and approved before their first use
+      and before changes are deployed to the production environment. The
+      version-level approval gate is the point at which that approval is
+      granted and recorded ahead of any production deployment.
+  - id: rts-art-17-1
+    note: >
+      Art. 17(1)(b) requires independence between the functions approving a
+      change and those requesting or implementing it — the basis for
+      requiring defined approver roles distinct from the delivery team.
+      Art. 17(1) also requires changes to be documented and verified before
+      production; the approval record bound to the version identity
+      evidences this per release.
+uk-fca_references:
+  - id: sysc-15a-2
+    note: >
+      Outcome-based rather than prescriptive: firms must be able to remain
+      within impact tolerances for important business services. Gating
+      production releases on explicit approval reduces the likelihood that
+      unauthorised or unready versions disrupt those services, and the
+      retained approval records evidence this capability in the firm's
+      operational resilience self-assessment.
+  - id: pra-ss1-21
+    note: >
+      The PRA's parallel expectations for dual-regulated firms. Same mapping
+      logic as SYSC 15A: version-level release approval is evidence of the
+      technology-change leg of the firm's resilience capability.
+  - id: fca-tech-change
+    note: >
+      The FCA's multi-firm review found failed technology changes cause
+      roughly a quarter of high-severity incidents, and that strong
+      governance and robust pre-deployment assurance correlate with higher
+      change success rates — directly supporting a defined, risk-tiered
+      approval gate at the version level.
+ffiec-itbooklets_references:
+  - id: dam-2
+    note: >
+      Governance of development, acquisition, and maintenance: management
+      oversight, defined roles and responsibilities, and accountability for
+      approving what is delivered into production. Named approver roles with
+      recorded, attributable decisions implement this expectation at the
+      release level.
+  - id: dam-7
+    note: >
+      Maintenance covers change management over operational systems,
+      including expectations that changes are authorised before
+      implementation and that change records are retained. The version-level
+      approval state, bound to an immutable version identity, is the
+      authorisation record for each release.
 mitigates:
   - ri-12  # Business Reputation Risk from Non-Approved Software Version Releases
 related_mitigations:
   - mi-12  # Deployment Gating
-
 ---
 
 ## Summary
 
-Version Release Approval Gating ensures that no software version is promoted to production without passing a defined approval workflow, enforced either by designated human approvers, automated policy checks, or a combination of both. It establishes a verifiable, auditable gate at the version level—distinct from per-deployment gates—that confirms the release candidate has satisfied all governance, quality, and risk requirements before any deployment is permitted.
+Version Release Approval Gating ensures that no software version is promoted to production without satisfying a defined approval process, enforced by designated human approvers, automated policy checks, or a combination of both. It establishes a verifiable, auditable gate at the version level — distinct from per-deployment gates — that confirms the release candidate has satisfied all governance, quality, and risk requirements before any deployment is permitted.
 
 ## Description
 
-Deployment gating ([MI-12]({% link _mitigations/mi-12_deployment-gating.md %})) controls whether an individual deployment job may proceed based on technical policy checks. Version Release Approval Gating operates at a higher level: it governs whether a named software version has received the organisational approval required to be released at all. A version may pass all automated deployment gates but still require explicit sign-off from a release manager, risk officer, or compliance stakeholder before it can be promoted from a candidate to an approved release.
+Deployment gating ([mi-12]({% link _mitigations/mi-12_deployment-gating.md %})) controls whether an individual deployment job may proceed based on technical policy checks. Version Release Approval Gating operates at a higher level: it governs whether a named software version has received the organisational approval required to be released at all. A version may pass all automated deployment gates but still require explicit sign-off from a release manager, risk officer, or compliance stakeholder before it can be promoted from a candidate to an approved release.
 
 This distinction is critical in regulated financial services environments where change management frameworks require named human accountability for production releases, not merely automated technical policy satisfaction.
 
-The control supports two complementary approval mechanisms that may be used individually or in combination:
+Two complementary approval mechanisms may be used individually or in combination:
 
 **Manual Approval Workflows**
-Named approvers—such as a release manager, change advisory board (CAB) member, or risk officer—explicitly authorise a release candidate before it can proceed to any production deployment. The approval is recorded against the specific version, is timestamped and attributed to an identified individual, and must be obtained before any deployment pipeline for that version is unlocked. Approval workflows may be tiered, requiring different sets of approvers depending on the risk classification of the application or the scope of the change.
+Named approvers — such as a release manager, change advisory board (CAB) member, or risk officer — explicitly authorise a release candidate before it can proceed to any production deployment. The approval is recorded against the specific version, is timestamped and attributed to an identified individual, and must be obtained before any deployment of that version is permitted. Approval workflows may be tiered, requiring different sets of approvers depending on the risk classification of the application or the scope of the change.
 
 **Automated Policy Checks**
 Policy-as-code evaluations assess the release candidate against a defined set of criteria that must all pass before the version is marked approved. These checks may include confirmation that all required test suites have executed and passed, that vulnerability findings are within approved thresholds, that security scan results have been attested, that mandatory review steps in the development workflow are complete, and that the release artefact matches a signed, verified build provenance record. Automated checks produce a structured approval record that can be used as audit evidence independently of human action.
 
-In either case, the approval state is recorded at the version level in a system of record (e.g., a release management platform, ITSM tool, or policy engine), and downstream deployment pipelines are blocked from proceeding until the required approval state is confirmed.
+In either case, the approval state is recorded at the version level in a system of record, and production deployment of the version is technically prevented until the required approval state is confirmed.
 
 ## Requirements
 
-* Every software version intended for production MUST be subject to a defined approval workflow before any production deployment is initiated
-* The approval workflow MUST be enforced by the release pipeline; pipelines MUST verify the approval state of the target version before proceeding and MUST fail if approval is absent or has been revoked
-* Approval workflows MUST specify which approver roles or automated checks are required, differentiated by application risk classification where appropriate
+* Every software version intended for production MUST be subject to a defined approval process before any production deployment is initiated
+* Production deployment of a version MUST be technically prevented while the required approval for that version is absent or has been revoked
+* The approval process MUST specify which approver roles or automated checks are required, differentiated by application risk classification where appropriate
 * Manual approvals MUST be attributed to a named individual, timestamped, and recorded in an auditable system of record
 * Automated approval checks MUST produce a structured, machine-readable result that is retained as part of the release record
-* Approval state MUST be bound to a specific, immutable version identifier (e.g., a signed artefact digest or tagged commit SHA); approval of one version MUST NOT be transferable to another
-* A documented emergency release process MUST exist for critical production incidents requiring deployment of a non-approved version. Emergency releases MUST require real-time approval from a named authority, MUST be time-bounded, MUST be logged with documented justification, and MUST trigger a post-incident governance review
-* Emergency release overrides MUST be reported to risk and compliance functions within a defined timeframe (e.g., next business day)
-* Approval records, including any overrides, MUST be retained for a period consistent with applicable regulatory requirements and the organisation's record-keeping policy
+* Approval state MUST be bound to an immutable, content-addressable identity for the released version; approval of one version MUST NOT be transferable to another
+* Approval records MUST be retained for a period consistent with applicable regulatory requirements and the organisation's record-keeping policy
 * The set of required approval checks and approver roles MUST be reviewed at least annually, or following any material change in the application's risk profile, regulatory obligations, or technology stack
 
 ## Examples & Commentary
 
-* **CAB-Gated Release:** For a high-criticality payment processing service, the release workflow requires approval from a release manager and a risk officer before the pipeline is permitted to deploy any build to production. The CAB review is documented in the ITSM system against the specific version tag, and the deployment pipeline queries the ITSM API to confirm approval state before executing any production deployment steps.
+* **CAB-Gated Release:** For a high-criticality payment processing service, the release workflow requires approval from a release manager and a risk officer before the pipeline is permitted to deploy any build to production. The CAB review is documented in the ITSM system against the specific version identity, and the deployment pipeline queries the ITSM API to confirm approval state before executing any production deployment steps.
 
 * **Automated Policy-as-Code Approval:** For a lower-risk internal tooling service, a policy engine evaluates the release candidate against a ruleset: all unit and integration tests passed, no critical CVEs in dependencies, SAST scan completed with no new high findings, and build provenance attestation verified. When all checks pass, the policy engine issues a signed approval record that the deployment pipeline accepts as authorisation to proceed.
 
-* **Tiered Approval by Change Risk:** An organisation classifies changes as standard, significant, or emergency. Standard changes (low-risk, well-understood) may be approved by automated policy checks alone. Significant changes require a named release manager sign-off in addition to automated checks. Emergency changes require a senior technology officer approval, are time-limite, and trigger mandatory post-deployment review.
+* **Tiered Approval by Change Risk:** An organisation classifies changes as standard or significant. Standard changes (low-risk, well-understood) may be approved by automated policy checks alone. Significant changes require a named release manager sign-off in addition to automated checks.
 
-* **Approval Binding to Artefact Digest:** To prevent version substitution attacks or accidental promotion of a different build, approval is recorded against the SHA-256 digest of the release artefact rather than a version label alone. The pipeline verifies both that the version label matches an approved record and that the artefact digest matches the digest recorded at approval time.
+* **Approval Binding to Artefact Digest:** To prevent version substitution attacks or accidental promotion of a different build, approval is recorded against the digest of the release artefact rather than a version label alone. The enforcement point verifies both that the version label matches an approved record and that the artefact digest matches the digest recorded at approval time.
 
-* **Revocation:** If a vulnerability is discovered in a version that has already been approved but not yet fully deployed, the approval can be revoked in the system of record, and the deployment pipeline will reject further deployments of that version until a new approval is granted for a remediated build.
+* **Enforcement mechanisms:** Technical prevention of unapproved deployment may be implemented in the deployment pipeline, in the deployment platform's environment protection rules, in an ITSM integration that locks deployment jobs pending change-record approval, or in a policy engine fronting the production environment. The control requires the prevention property, not any particular mechanism.
+
+* **Revocation:** If a vulnerability is discovered in a version that has already been approved but not yet fully deployed, the approval can be revoked in the system of record, and further deployments of that version are rejected until a new approval is granted for a remediated build.
 
 ## Links
 
+* [NIST SP 800-53r5 CM-3: Configuration Change Control](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
+* [FFIEC IT Handbook — Development, Acquisition, and Maintenance booklet](https://ithandbook.ffiec.gov/it-booklets/development-acquisition-and-maintenance/)
+* [GitHub deployment protection rules documentation](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment)

--- a/docs/_mitigations/mi-19_version-approval.md
+++ b/docs/_mitigations/mi-19_version-approval.md
@@ -70,6 +70,9 @@ mitigates:
   - ri-12  # Business Reputation Risk from Non-Approved Software Version Releases
 related_mitigations:
   - mi-12  # Deployment Gating
+  - mi-20  # Requirements Approval for Release
+  - mi-3   # Software Artifact Provenance
+  - mi-1   # Code Review
 ---
 
 ## Summary
@@ -88,9 +91,9 @@ Two complementary approval mechanisms may be used individually or in combination
 Named approvers — such as a release manager, change advisory board (CAB) member, or risk officer — explicitly authorise a release candidate before it can proceed to any production deployment. The approval is recorded against the specific version, is timestamped and attributed to an identified individual, and must be obtained before any deployment of that version is permitted. Approval workflows may be tiered, requiring different sets of approvers depending on the risk classification of the application or the scope of the change.
 
 **Automated Policy Checks**
-Policy-as-code evaluations assess the release candidate against a defined set of criteria that must all pass before the version is marked approved. These checks may include confirmation that all required test suites have executed and passed, that vulnerability findings are within approved thresholds, that security scan results have been attested, that mandatory review steps in the development workflow are complete, and that the release artefact matches a signed, verified build provenance record. Automated checks produce a structured approval record that can be used as audit evidence independently of human action.
+Policy-as-code evaluations confirm that the evidence and decisions required for release exist before the version is marked approved: deployment gate criteria satisfied ([mi-12]({% link _mitigations/mi-12_deployment-gating.md %})), mandatory review steps complete ([mi-1]({% link _mitigations/mi-1_code-review.md %})), release-scope requirements agreed ([mi-20]({% link _mitigations/mi-20_requirements-approval.md %})), and the release artefact matched to verified build provenance ([mi-3]({% link _mitigations/mi-3_software-artifact-provenance.md %})). Evaluating the technical posture of the artefact itself — scan findings, test results, remediation timelines — is the domain of deployment gating; the distinguishing output of an automated release approval is a durable, attributable approval record that can be used as audit evidence independently of human action.
 
-In either case, the approval state is recorded at the version level in a system of record, and production deployment of the version is technically prevented until the required approval state is confirmed.
+In either case, the approval state is recorded at the release level in a system of record, and production deployment is technically prevented until the required approval state is confirmed. The approval state is typically one of the conditions a deployment gate ([mi-12]({% link _mitigations/mi-12_deployment-gating.md %})) verifies at each deployment event.
 
 ## Requirements
 

--- a/docs/_mitigations/mi-20_requirements-approval.md
+++ b/docs/_mitigations/mi-20_requirements-approval.md
@@ -11,7 +11,7 @@ chain:
   - requirements-governance
 related_mitigations:
   - mi-4   # Requirements Repository
-  - mi-19  # Version Release Approval Gating
+  - mi-19  # Release Approval Gating
 ---
 
 ## Summary

--- a/docs/_risks/ri-12_business-reputation.md
+++ b/docs/_risks/ri-12_business-reputation.md
@@ -7,7 +7,7 @@ type: BUS
 related_risks:
   - ri-8   # Unauthorised Change
 mitigations:
-  - mi-19  # Version Release Approval Gating
+  - mi-19  # Release Approval Gating
   - mi-12  # Deployment Gating
 ---
 ## Summary


### PR DESCRIPTION
Reworks MI-19 into **Release Approval Gating** and sharpens its boundary with MI-12.

## MI-19 — Release Approval Gating

**Renamed and broadened.** The gate applies to any versioned release — a software artifact, an infrastructure-as-code change set, or both — not only application software. The URL slug is unchanged to preserve existing links.

**Requirements refocused on outcomes rather than implementation:**
- The pipeline-specific enforcement requirement ("MUST be enforced by the release pipeline... pipelines MUST verify... MUST fail") is now a mechanism-neutral property: *production deployment MUST be technically prevented while the required approval is absent or revoked*. The ways to implement that (pipeline, environment protection rules, ITSM lock, policy engine) move to Examples & Commentary.
- Approval binding is now to an *immutable, content-addressable identity* rather than the inline examples ("signed artefact digest or tagged commit SHA") — a tag is mutable, and a commit identifies source rather than the released artefact. This follows the wording direction in #81.
- The two emergency-release requirements are removed: control bypass is being consolidated into a dedicated control (#81) rather than restated per mitigation.

**Regulatory mappings added**, following the format piloted on MI-1 in #88: NIST 800-53 (CM-3, CM-5, CA-6), EU DORA (Art. 9(4)(e), RTS Arts. 16(2) and 17(1)), UK FCA/PRA (SYSC 15A, SS1/21, FCA technology-change review), FFIEC DAM (II Governance, VII Maintenance).

**Quality pass:** the empty `## Links` section is populated; lowercase cross-refs; meta-reference phrasing removed from the Description; the "time-limite" typo resolved by removing the emergency tier from the tiered-approval example.

## MI-12 / MI-19 boundary

Reviewed side by side, MI-19's automated-checks paragraph re-enumerated MI-12's gate criteria (tests passed, vulnerability thresholds, scan attestations), making the two controls read as duplicates. They answer different questions:

- **MI-12** evaluates the *current technical posture* of an artefact at each deployment event — the same version can pass today and be blocked tomorrow as new findings emerge, scans age, or remediation timelines are breached.
- **MI-19** issues a *durable, attributable approval record* per release, bound to the release identity; that approval state is one of the conditions a deployment gate verifies.

Both descriptions now state this boundary explicitly and cross-link each other. MI-19's automated-checks paragraph now describes confirming that required evidence and decisions exist (mi-12, mi-1, mi-20, mi-3) and producing the approval record, leaving posture evaluation to mi-12.

MI-12's override requirements and its Emergency Overrides example are removed for the same reason as MI-19's: bypass consolidation per #81.

Refs #96, #81
